### PR TITLE
chore: update license specifier format in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name         = "infrared-protocols"
 version      = "1.0.1"
-license      = {text = "MIT"}
+license      = "MIT"
 description  = "Library to decode and encode infrared signals."
 readme       = "README.md"
 classifiers = [


### PR DESCRIPTION
Update license specifier format in pyproject since the previous format is deprecated.