### PR TITLE
fix: shorten NECCommand gap after initial command

### DIFF
--- a/infrared_protocols/commands.py
+++ b/infrared_protocols/commands.py
@@ -68,6 +68,7 @@ class NECCommand(Command):
         zero_low = 562
         one_low = 1687
         repeat_low = 2250
+        initial_frame_gap = 41000  # Gap to make total frame ~108ms
         frame_gap = 96000  # Gap to make total frame ~108ms
 
         timings: list[Timing] = [Timing(high_us=leader_high, low_us=leader_low)]
@@ -105,10 +106,12 @@ class NECCommand(Command):
         timings.append(Timing(high_us=bit_high, low_us=0))
 
         # Add repeat codes if requested
+        gap = initial_frame_gap
         for _ in range(self.repeat_count):
             # Replace the last timing's low_us with the frame gap
             last_timing = timings[-1]
-            timings[-1] = Timing(high_us=last_timing.high_us, low_us=frame_gap)
+            timings[-1] = Timing(high_us=last_timing.high_us, low_us=gap)
+            gap = frame_gap  # Use standard frame gap for subsequent repeats
 
             # Repeat code: leader burst + shorter space + end pulse
             timings.extend(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -55,7 +55,7 @@ def test_nec_command_get_raw_timings_standard() -> None:
     timings_with_repeats = command_with_repeats.get_raw_timings()
     assert timings_with_repeats == [
         *expected_raw_timings[:-1],
-        Timing(high_us=562, low_us=96000),
+        Timing(high_us=562, low_us=41000),
         Timing(high_us=9000, low_us=2250),
         Timing(high_us=562, low_us=96000),
         Timing(high_us=9000, low_us=2250),
@@ -116,7 +116,7 @@ def test_nec_command_get_raw_timings_extended() -> None:
     timings_with_repeats = command_with_repeats.get_raw_timings()
     assert timings_with_repeats == [
         *expected_raw_timings[:-1],
-        Timing(high_us=562, low_us=96000),
+        Timing(high_us=562, low_us=41000),
         Timing(high_us=9000, low_us=2250),
         Timing(high_us=562, low_us=96000),
         Timing(high_us=9000, low_us=2250),


### PR DESCRIPTION
For the first repeat, since a full command was just sent there is less time until the 108ms inter-frame spacing than on later iterations. Reduce the first gap to 41ms from 96ms.