### PR TITLE
chore: symlink CLAUDE.md to AGENTS.md and ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-# uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` as a symlink to `AGENTS.md` so Claude Code picks up the same agent guidance without duplicating content.
- Uncomment `uv.lock` in `.gitignore` so the lockfile is no longer tracked (appropriate for a library).

## Test plan
- [x] `git check-ignore -v uv.lock` resolves to `.gitignore:101`
- [x] `CLAUDE.md` resolves to `AGENTS.md` via symlink