### PR TITLE
chore: fix prek not running on any files on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install prek
       - name: Run prek
-        run: |
-          prek
+        uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 # v2.0.2
+        env:
+          RUFF_OUTPUT_FORMAT: github
 
   pytest:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
         files: ^infrared_protocols/
       - id: ruff-format


### PR DESCRIPTION
Running just `prek` on a PR CI doesn't do anything because there are no staged files for prek to check. Use the same github action used by HA instead.