### PR TITLE
feat: add Marantz Amplifier PM6006

### DIFF
--- a/infrared_protocols/codes/marantz/pm6006.py
+++ b/infrared_protocols/codes/marantz/pm6006.py
@@ -1,0 +1,65 @@
+"""Command codes for the Marantz PM6006 integrated amplifier."""
+
+from enum import Enum
+
+from ...commands import Command
+from ...commands.marantz_extended import MarantzExtendedCommand
+from ...commands.rc5 import RC5Command
+
+
+class MarantzPM6006Code(Enum):
+    """Marantz PM6006 IR command codes."""
+
+    # System 0x10 (Audio Amplifier)
+    POWER = (0x10, 0x0C)
+    MUTE = (0x10, 0x0D)
+    VOLUME_UP = (0x10, 0x10)
+    VOLUME_DOWN = (0x10, 0x11)
+    SPEAKER_AB = (0x10, 0x1D)
+    SOURCE_DIRECT = (0x10, 0x22)
+    LOUDNESS = (0x10, 0x32)
+
+    # Analog source selection.
+    SOURCE_CD = (0x14, 0x3F)
+    SOURCE_CDR = (0x1A, 0x3F)
+    SOURCE_PHONO = (0x15, 0x3F)
+    SOURCE_TUNER = (0x11, 0x3F)
+
+    # SOURCE_OPTICAL toggles between the two optical inputs on the amplifier.
+    SOURCE_OPTICAL = (0x10, 0x01, 0x28)
+    SOURCE_NETWORK = (0x19, 0x3F, 0x0A)
+    SOURCE_COAX = (0x10, 0x01, 0x19)
+
+    def to_command(self, repeat_count: int = 0, *, toggle: int = 0) -> Command:
+        """Build the IR command for this Marantz PM6006 code."""
+        code_tuple = self.value
+        if len(code_tuple) == 3:
+            address, command, extension = code_tuple
+            return MarantzExtendedCommand(
+                address=address,
+                command=command,
+                extension=extension,
+                toggle=toggle,
+                repeat_count=repeat_count,
+            )
+
+        if len(code_tuple) != 2:
+            raise ValueError("Marantz PM6006 codes must define exactly 2 or 3 values")
+
+        address, command = code_tuple
+        return RC5Command(
+            address=address,
+            command=command,
+            toggle=toggle,
+            repeat_count=repeat_count,
+        )
+
+
+def make_command(
+    code: MarantzPM6006Code,
+    repeat_count: int = 0,
+    *,
+    toggle: int = 0,
+) -> Command:
+    """Build the IR command for a Marantz PM6006 code."""
+    return code.to_command(repeat_count=repeat_count, toggle=toggle)

--- a/infrared_protocols/commands/marantz_extended.py
+++ b/infrared_protocols/commands/marantz_extended.py
@@ -1,0 +1,88 @@
+"""Marantz extended IR command."""
+
+from typing import override
+
+from . import Command
+from .rc5 import (
+    RC5_HALF_BIT_US,
+    RC5_MODULATION_HZ,
+    RC5_REPEAT_PERIOD_US,
+    append_signed_us,
+    manchester_encode_bit,
+    strip_idle_edges,
+)
+
+# The pause inserted between the address and command fields is exactly four
+# RC-5 half-bit units of pure space.
+_MARANTZ_PAUSE_US = 4 * RC5_HALF_BIT_US
+
+
+class MarantzExtendedCommand(Command):
+    """Marantz extended IR command."""
+
+    address: int
+    command: int
+    extension: int
+    toggle: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        extension: int,
+        toggle: int = 0,
+        modulation: int = RC5_MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Marantz extended IR command."""
+        if not 0 <= address <= 0x1F:
+            raise ValueError("Marantz address must be in range 0x00..0x1F")
+        if not 0 <= command <= 0x7F:
+            raise ValueError("Marantz command must be in range 0x00..0x7F")
+        if not 0 <= extension <= 0x3F:
+            raise ValueError("Marantz extension must be in range 0x00..0x3F")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.extension = extension
+        self.toggle = toggle
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Marantz extended command."""
+        start_bit_2 = 0 if self.command & 0x40 else 1
+        command_bits = self.command & 0x3F
+
+        # First 8 bits: S1, S2/field, T, A4..A0 (MSB first).
+        leader_bits: list[int] = [1, start_bit_2, self.toggle & 1]
+        for i in range(4, -1, -1):
+            leader_bits.append((self.address >> i) & 1)
+
+        # Last 12 bits: C5..C0 (MSB first), then E5..E0 (MSB first).
+        trailing_bits: list[int] = []
+        for i in range(5, -1, -1):
+            trailing_bits.append((command_bits >> i) & 1)
+        for i in range(5, -1, -1):
+            trailing_bits.append((self.extension >> i) & 1)
+
+        frame: list[int] = []
+        for bit in leader_bits:
+            manchester_encode_bit(frame, bit, RC5_HALF_BIT_US)
+        # The pause is a fixed-length space; merge with whatever space
+        # came before it (the trailing half of A0 if A0 == 0).
+        append_signed_us(frame, -_MARANTZ_PAUSE_US)
+        for bit in trailing_bits:
+            manchester_encode_bit(frame, bit, RC5_HALF_BIT_US)
+        strip_idle_edges(frame)
+
+        timings = list(frame)
+
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in frame)
+            gap = RC5_REPEAT_PERIOD_US - frame_duration
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(frame)
+
+        return timings

--- a/infrared_protocols/commands/rc5.py
+++ b/infrared_protocols/commands/rc5.py
@@ -1,0 +1,138 @@
+"""RC-5 IR command (Philips, Marantz, and other devices)."""
+
+from typing import override
+
+from . import Command
+
+# RC-5 timing unit (half-bit) in microseconds. The full bit period is 2 × this.
+RC5_HALF_BIT_US = 889
+# RC-5 carrier frequency in Hz.
+RC5_MODULATION_HZ = 36000
+# Time between the start of one frame and the start of the next while a key is
+# held. A standard 14-bit RC-5 frame fits inside this with idle space to spare.
+RC5_REPEAT_PERIOD_US = 114000
+
+
+def append_signed_us(timings: list[int], value: int) -> None:
+    """Append a microsecond duration, merging into the last entry if same sign."""
+    if timings and (timings[-1] > 0) == (value > 0):
+        timings[-1] += value
+    else:
+        timings.append(value)
+
+
+def manchester_encode_bit(timings: list[int], bit: int, half_bit_us: int) -> None:
+    """Append the two Manchester half-bits for ``bit`` to ``timings``.
+
+    Logic '0' is a burst followed by a space; logic '1' is a space followed
+    by a burst. Adjacent halves of equal sign are merged.
+    """
+    if bit:
+        append_signed_us(timings, -half_bit_us)
+        append_signed_us(timings, half_bit_us)
+    else:
+        append_signed_us(timings, half_bit_us)
+        append_signed_us(timings, -half_bit_us)
+
+
+def strip_idle_edges(timings: list[int]) -> None:
+    """Drop any leading and trailing space (negative) entries in place.
+
+    Manchester-encoded frames include an idle space before the first burst
+    (when the leading bit's first half is space) and may end on a space.
+    Neither carries information, so we strip them to keep a clean
+    pulse-bracketed timing list.
+    """
+    if timings and timings[0] < 0:
+        timings.pop(0)
+    if timings and timings[-1] < 0:
+        timings.pop()
+
+
+class RC5Command(Command):
+    """RC-5 IR command (Philips, Marantz amplifiers, and similar devices).
+
+    This is the protocol used by Marantz integrated amplifiers such as the
+    PM6006, by Philips consumer electronics, and by many other devices that
+    adopted the Philips RC-5 standard.
+
+    Both standard RC-5 (5-bit address, 6-bit command) and the extended
+    RC-5 / RC5X variant (5-bit address, 7-bit command) are supported.
+    A ``command`` with bit 6 set automatically selects the extended
+    encoding (with the second start bit re-purposed as the inverted MSB
+    of the command).
+    """
+
+    address: int
+    command: int
+    toggle: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        toggle: int = 0,
+        modulation: int = RC5_MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the RC-5 IR command."""
+        if not 0 <= address <= 0x1F:
+            raise ValueError("RC-5 address must be in range 0x00..0x1F")
+        if not 0 <= command <= 0x7F:
+            raise ValueError("RC-5 command must be in range 0x00..0x7F")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.toggle = toggle
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the RC-5 command.
+
+        RC-5 protocol timing (in microseconds):
+        - Carrier: 36 kHz
+        - Bit time: 1778µs (half-bit: 889µs)
+        - Frame: 14 bits, Manchester encoded
+          (S1, S2, T, A4..A0 MSB first, C5..C0 MSB first)
+        - Logical '0': burst in first half of bit time (high then low)
+        - Logical '1': burst in second half of bit time (low then high)
+        - Total frame duration: ~25ms
+        - Repeat period: 114ms (key still pressed)
+
+        For extended RC-5 (command bit 6 set) the second start bit
+        ``S2`` is replaced by the inverted MSB of the 7-bit command,
+        providing a 7-bit command field.
+        """
+        # S2 is the inverted MSB (bit 6) of the 7-bit command. For
+        # standard RC-5 (bit 6 clear) this is 1, the original idle-frame
+        # marker; for RC5X commands (bit 6 set) it is 0.
+        start_bit_2 = 0 if self.command & 0x40 else 1
+        command_bits = self.command & 0x3F
+
+        # Build the 14-bit frame: S1, S2, T, address (MSB first),
+        # command (MSB first).
+        bits: list[int] = [1, start_bit_2, self.toggle & 1]
+        for i in range(4, -1, -1):
+            bits.append((self.address >> i) & 1)
+        for i in range(5, -1, -1):
+            bits.append((command_bits >> i) & 1)
+
+        frame: list[int] = []
+        for bit in bits:
+            manchester_encode_bit(frame, bit, RC5_HALF_BIT_US)
+        strip_idle_edges(frame)
+
+        timings = list(frame)
+
+        # Repeats are the same frame retransmitted every 114ms while the
+        # key remains pressed. The toggle bit only flips between distinct
+        # key presses, so it stays constant across repeats.
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in frame)
+            gap = RC5_REPEAT_PERIOD_US - frame_duration
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(frame)
+
+        return timings

--- a/tests/commands/test_marantz_extended.py
+++ b/tests/commands/test_marantz_extended.py
@@ -1,0 +1,150 @@
+"""Tests for the Marantz extended (RC-5 + extension) IR command encoder."""
+
+import pytest
+
+from infrared_protocols.commands.marantz_extended import MarantzExtendedCommand
+
+
+def test_marantz_extended_get_raw_timings_pm6006_coax() -> None:
+    """Encode the PM6006 COAX selector (addr=0x10, cmd=0x01, ext=0x19).
+
+    The expected timing sequence was hand-derived from the protocol
+    definition (S1, S2, T, A4..A0 + 4-half-bit pause + C5..C0, E5..E0)
+    and matches a real Marantz PM6006 capture to within measurement
+    noise (e.g. 889µs encoded vs. 904-965µs captured).
+    """
+    expected = [
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        1778,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -4445,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -1778,
+        1778,
+        -1778,
+        889,
+        -889,
+        1778,
+        -889,
+        889,
+        -1778,
+        889,
+    ]
+    command = MarantzExtendedCommand(
+        address=0x10, command=0x01, extension=0x19, toggle=1
+    )
+    assert command.get_raw_timings() == expected
+    assert command.modulation == 36000
+
+
+def test_marantz_extended_get_raw_timings_pm6006_network() -> None:
+    """Encode the PM6006 NETWORK selector (addr=0x19, cmd=0x3F, ext=0x0A).
+
+    Verifies a frame whose last bit is '0' (so the trailing space is
+    stripped) and whose address LSB is '1' (so the pause does not merge
+    with a preceding space).
+    """
+    expected = [
+        889,
+        -889,
+        1778,
+        -1778,
+        889,
+        -889,
+        1778,
+        -889,
+        889,
+        -1778,
+        889,
+        -4445,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        1778,
+        -889,
+        889,
+        -1778,
+        1778,
+        -1778,
+        1778,
+    ]
+    command = MarantzExtendedCommand(
+        address=0x19, command=0x3F, extension=0x0A, toggle=0
+    )
+    assert command.get_raw_timings() == expected
+
+
+def test_marantz_extended_repeats_match_rc5_period() -> None:
+    """Repeats reuse the standard RC-5 114ms period so the gap is derived."""
+    command = MarantzExtendedCommand(
+        address=0x10, command=0x01, extension=0x19, toggle=1, repeat_count=2
+    )
+    base = MarantzExtendedCommand(
+        address=0x10, command=0x01, extension=0x19, toggle=1
+    ).get_raw_timings()
+    timings = command.get_raw_timings()
+    frame_duration = sum(abs(t) for t in base)
+    gap = 114000 - frame_duration
+    assert timings == [*base, -gap, *base, -gap, *base]
+
+
+def test_marantz_extended_extended_command_clears_s2() -> None:
+    """Bit 6 of ``command`` re-purposes S2 (RC5X behaviour, same as RC-5)."""
+    standard = MarantzExtendedCommand(
+        address=0x10, command=0x01, extension=0x00, toggle=0
+    ).get_raw_timings()
+    extended = MarantzExtendedCommand(
+        address=0x10, command=0x41, extension=0x00, toggle=0
+    ).get_raw_timings()
+    # Same total duration; differ on the S2 half.
+    assert standard != extended
+    assert sum(abs(t) for t in standard) == sum(abs(t) for t in extended)
+    # S2=0 → frame opens with a merged 1778µs double-burst (S1 burst + S2 burst).
+    assert extended[0] == 1778
+    assert standard[0] == 889
+
+
+@pytest.mark.parametrize(
+    ("address", "command", "extension"),
+    [
+        (-1, 0x00, 0x00),
+        (0x20, 0x00, 0x00),
+        (0x10, -1, 0x00),
+        (0x10, 0x80, 0x00),
+        (0x10, 0x00, -1),
+        (0x10, 0x00, 0x40),
+    ],
+)
+def test_marantz_extended_rejects_out_of_range(
+    address: int, command: int, extension: int
+) -> None:
+    """5-bit address, 7-bit command, 6-bit extension — anything else is invalid."""
+    with pytest.raises(ValueError):
+        MarantzExtendedCommand(
+            address=address, command=command, extension=extension, toggle=0
+        )

--- a/tests/commands/test_rc5.py
+++ b/tests/commands/test_rc5.py
@@ -1,0 +1,142 @@
+"""Tests for the RC-5 IR command encoder."""
+
+import pytest
+
+from infrared_protocols.commands.rc5 import RC5Command
+
+
+def test_rc5_command_get_raw_timings_marantz_volume_up() -> None:
+    """Test RC-5 timings for a Marantz amplifier volume-up press.
+
+    Marantz integrated amplifiers (e.g. PM6006) use RC-5 with address
+    0x10 (audio amplifier). Command 0x10 is volume up.
+    """
+    expected_raw_timings = [
+        889,
+        -889,
+        1778,
+        -1778,
+        1778,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -1778,
+        1778,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+    ]
+    command = RC5Command(address=0x10, command=0x10, toggle=0, repeat_count=0)
+    timings = command.get_raw_timings()
+    assert timings == expected_raw_timings
+    assert command.modulation == 36000
+
+    # Same command repeated twice with the standard 114ms RC-5 period.
+    command_with_repeats = RC5Command(
+        address=command.address,
+        command=command.command,
+        toggle=command.toggle,
+        modulation=command.modulation,
+        repeat_count=2,
+    )
+    timings_with_repeats = command_with_repeats.get_raw_timings()
+    assert timings_with_repeats == [
+        *expected_raw_timings,
+        -90886,
+        *expected_raw_timings,
+        -90886,
+        *expected_raw_timings,
+    ]
+
+
+def test_rc5_command_get_raw_timings_zero_address_zero_command() -> None:
+    """Test RC-5 timings for the all-zero address/command edge case."""
+    expected_raw_timings = [
+        889,
+        -889,
+        1778,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+        -889,
+        889,
+    ]
+    command = RC5Command(address=0, command=0, toggle=0, repeat_count=0)
+    assert command.get_raw_timings() == expected_raw_timings
+
+
+def test_rc5_command_get_raw_timings_extended() -> None:
+    """Test extended RC-5 (RC5X) handling for 7-bit commands.
+
+    With command bit 6 set, the second start bit is repurposed as the
+    inverted MSB of the command. The extended frame must differ from
+    the standard frame yet preserve the 14-bit total duration.
+    """
+    extended = RC5Command(address=0x10, command=0x50, toggle=0)
+    standard_equivalent = RC5Command(address=0x10, command=0x10, toggle=0)
+    extended_timings = extended.get_raw_timings()
+    standard_timings = standard_equivalent.get_raw_timings()
+    assert extended_timings != standard_timings
+    # S1=1, S2=0 means the first two halves are space, pulse, pulse — so
+    # after stripping the leading idle space the frame begins with a
+    # 1778µs double-burst rather than the 889µs single burst seen in
+    # standard RC-5.
+    assert extended_timings[0] == 1778
+    assert standard_timings[0] == 889
+    # Frame total duration is invariant across S2 values.
+    assert sum(abs(t) for t in extended_timings) == sum(
+        abs(t) for t in standard_timings
+    )
+
+
+def test_rc5_command_extended_triggered_by_command_bit_6() -> None:
+    """The extended encoding must key off bit 6, not magnitude.
+
+    ``command=0x40`` is the smallest RC5X command and must produce the
+    same S2=0 frame shape as the existing 0x50 case (1778µs double-burst
+    leader after stripping the idle space).
+    """
+    command_0x40 = RC5Command(address=0x10, command=0x40, toggle=0)
+    command_0x50 = RC5Command(address=0x10, command=0x50, toggle=0)
+    assert command_0x40.get_raw_timings()[0] == 1778
+    assert command_0x50.get_raw_timings()[0] == 1778
+
+
+@pytest.mark.parametrize(
+    ("address", "command"),
+    [
+        (-1, 0x00),
+        (0x20, 0x00),
+        (0x10, -1),
+        (0x10, 0x80),
+    ],
+)
+def test_rc5_command_rejects_out_of_range(address: int, command: int) -> None:
+    """RC-5 fields are 5-bit address / 7-bit command — anything else is invalid."""
+    with pytest.raises(ValueError):
+        RC5Command(address=address, command=command, toggle=0)


### PR DESCRIPTION
This adds the codes for the Marantz PM6006 amplifier. I was able to find some generic commands with their RC-5 codes, but had to fallback to raw timings to find the last 3 commands.

Other downsides:
- no dedicated power on and power off signals
- no specific volume set
- no specific optical set (it toggles between optical 1 and 2)

Not a receiver to recommend for programmatic control, but the one I had at hand.

Used the following command to try to find other codes:

<details>

```python
#!/usr/bin/env python3
# /// script
# requires-python = ">=3.13"
# dependencies = [
#   "aioesphomeapi>=24.0",
# ]
# ///
"""Walk RC-5 system addresses on a Marantz amp and label what each one does.

Connects to an ESPHome IR transmitter over the native API and sends one
RC-5 frame per address (command 0x3F). After each frame, prompts for a
label: type a name and press Enter to save it, or just press Enter to
advance without saving.

Run with:

    uv run script/scan_marantz_sources.py [--host 192.168.1.215]
"""

from __future__ import annotations

import argparse
import asyncio
import sys
from pathlib import Path

from aioesphomeapi import APIClient, InfraredCapability, InfraredInfo

CARRIER_HZ = 36000
OUTPUT_FILE = Path(__file__).resolve().parent.parent / "marantz_scan_results.txt"


def rc5_raw_timings(address: int, command: int, toggle: int) -> list[int]:
    """Encode one standard RC-5 frame as signed pulse/space microseconds."""
    half_bit = 889
    bits = [1, 1, toggle & 1]
    for i in range(4, -1, -1):
        bits.append((address >> i) & 1)
    for i in range(5, -1, -1):
        bits.append((command >> i) & 1)

    timings: list[int] = []
    for bit in bits:
        first, second = (-half_bit, half_bit) if bit else (half_bit, -half_bit)
        for value in (first, second):
            if timings and (timings[-1] > 0) == (value > 0):
                timings[-1] += value
            else:
                timings.append(value)
    if timings and timings[0] < 0:
        timings.pop(0)
    if timings and timings[-1] < 0:
        timings.pop()
    return timings


async def prompt(message: str) -> str:
    """Read a line from stdin without blocking the event loop."""
    return await asyncio.to_thread(input, message)


async def find_ir_entity(client: APIClient) -> InfraredInfo:
    """Return the first infrared transmitter exposed by the device."""
    entities, _services = await client.list_entities_services()
    for entity in entities:
        if isinstance(entity, InfraredInfo) and (
            entity.capabilities & InfraredCapability.TRANSMITTER
        ):
            return entity
    raise SystemExit("No infrared transmitter entity found on the device.")


def load_saved_codes(path: Path) -> set[int]:
    """Read previously-labeled codes from the output file."""
    if not path.exists():
        return set()
    saved: set[int] = set()
    for line in path.read_text(encoding="utf-8").splitlines():
        token = line.split("\t", 1)[0].strip()
        if token.startswith("0x"):
            try:
                saved.add(int(token, 16))
            except ValueError:
                continue
    return saved


def parse_range(value: str) -> range:
    """Parse "0xNN" (single value) or "0xLO:0xHI" (inclusive range)."""
    if ":" in value:
        lo_str, hi_str = value.split(":", 1)
        lo, hi = int(lo_str, 0), int(hi_str, 0)
    else:
        lo = hi = int(value, 0)
    return range(lo, hi + 1)


async def scan(
    host: str,
    password: str | None,
    addresses: range,
    commands: range,
) -> None:
    """Connect, sweep (address, command) pairs, and capture user labels."""
    saved = load_saved_codes(OUTPUT_FILE)
    client = APIClient(host, 6053, password)
    await client.connect(login=True)
    try:
        ir = await find_ir_entity(client)
        print(f"Using IR entity {ir.name!r} (key={ir.key}, device_id={ir.device_id})")
        print(f"Output file: {OUTPUT_FILE}")
        if saved:
            print(f"Skipping {len(saved)} already-labeled code(s).")
        print(
            f"Sweeping addresses 0x{addresses.start:02X}..0x{addresses.stop - 1:02X} "
            f"x commands 0x{commands.start:02X}..0x{commands.stop - 1:02X}. "
            "Press Enter to advance; type a name first to save it. Ctrl+C to stop.\n"
        )

        toggle = 0
        with OUTPUT_FILE.open("a", encoding="utf-8") as out:
            for address in addresses:
                for command in commands:
                    code = (address << 8) | command
                    if code in saved:
                        continue
                    timings = rc5_raw_timings(address, command, toggle)
                    toggle ^= 1
                    client.infrared_rf_transmit_raw_timings(
                        ir.key,
                        carrier_frequency=CARRIER_HZ,
                        timings=timings,
                        device_id=ir.device_id,
                    )

                    name = (await prompt(f"0x{code:04X} > ")).strip()
                    if name:
                        out.write(f"0x{code:04X}\t{name}\n")
                        out.flush()
                        print(f"   saved: 0x{code:04X} -> {name}")
    finally:
        await client.disconnect()


def main() -> None:
    """Parse CLI args and run the scan."""
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--host", default="192.168.1.215")
    parser.add_argument("--password", default=None)
    parser.add_argument(
        "--addresses",
        default="0x10",
        help="RC-5 address(es) to sweep, e.g. '0x10' or '0x00:0x1F' (default: 0x10)",
    )
    parser.add_argument(
        "--commands",
        default="0x00:0x7F",
        help="RC-5 command(s) to sweep, e.g. '0x3F' or '0x00:0x7F' (default: 0x00:0x7F)",
    )
    args = parser.parse_args()
    try:
        asyncio.run(
            scan(
                args.host,
                args.password,
                parse_range(args.addresses),
                parse_range(args.commands),
            )
        )
    except KeyboardInterrupt:
        print("\nInterrupted.", file=sys.stderr)


if __name__ == "__main__":
    main()
```

</details>