### PR TITLE
feat: add LG TV service-menu IR codes (EZ Adjust, In-Start)

### DIFF
--- a/infrared_protocols/codes/lg/tv.py
+++ b/infrared_protocols/codes/lg/tv.py
@@ -14,6 +14,7 @@ class LGTVCode(IntEnum):
     CHANNEL_DOWN = 0x01
     CHANNEL_UP = 0x00
     EXIT = 0x5B
+    EZ_ADJUST = 0xFF
     FAST_FORWARD = 0x8E
     GREEN = 0x63
     GUIDE = 0xA9
@@ -24,6 +25,7 @@ class LGTVCode(IntEnum):
     HOME = 0x7C
     INFO = 0xAA
     INPUT = 0x0B
+    IN_START = 0xFB
     LIST = 0xCA
     MENU = 0x43
     MUTE = 0x09
@@ -143,6 +145,7 @@ class LGTVCodeJP(Enum):
     DTV_NUM_11 = (0xC404, 0xDB)
     DTV_NUM_12 = (0xC304, 0xDB)
     EXIT = (0xFB04, 0x5B)
+    EZ_ADJUST = (0xFB04, 0xFF)
     FAST_FORWARD = (0xFB04, 0x8E)
     GREEN = (0xFB04, 0x63)
     GUIDE = (0xFB04, 0xA9)
@@ -153,6 +156,7 @@ class LGTVCodeJP(Enum):
     HOME = (0xFB04, 0x7C)
     INFO = (0xFB04, 0xAA)
     INPUT = (0xFB04, 0x0B)
+    IN_START = (0xFB04, 0xFB)
     LIST = (0xFB04, 0x53)
     MENU = (0xFB04, 0x43)
     MUTE = (0xFB04, 0x09)


### PR DESCRIPTION
## Summary

- Add `EZ_ADJUST` (0xFF) and `IN_START` (0xFB) to both `LGTVCode` and `LGTVCodeJP`.
- The **In-Start** service-menu command is used to enable **RS232 support** on LG TVs.
- The **EZ Adjust** command opens the EZ Adjust service menu.

Both codes share the standard LG TV NEC address (`0xFB04`), so they slot into the existing enums alongside the user-facing codes.

## Test plan

- [x] `pytest` passes
- [x] `prek` (ruff, ruff-format, basedpyright) passes
- [x] Verified that `LGTVCode.EZ_ADJUST.to_command().get_raw_timings()` matches the wire format produced by the reference scripts (`script/send_lg_ez_adjust.py`, `script/send_lg_in_start.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)