### PR TITLE
feat!: remove make_command

### DIFF
--- a/infrared_protocols/codes/lg/tv.py
+++ b/infrared_protocols/codes/lg/tv.py
@@ -206,8 +206,3 @@ class LGTVCodeJP(Enum):
             command=command,
             repeat_count=repeat_count,
         )
-
-
-def make_command(code: LGTVCode, repeat_count: int = 0) -> Command:
-    """Build an NEC command for an LG TV IR code."""
-    return code.to_command(repeat_count)

--- a/infrared_protocols/codes/marantz/pm6006.py
+++ b/infrared_protocols/codes/marantz/pm6006.py
@@ -53,13 +53,3 @@ class MarantzPM6006Code(Enum):
             toggle=toggle,
             repeat_count=repeat_count,
         )
-
-
-def make_command(
-    code: MarantzPM6006Code,
-    repeat_count: int = 0,
-    *,
-    toggle: int = 0,
-) -> Command:
-    """Build the IR command for a Marantz PM6006 code."""
-    return code.to_command(repeat_count=repeat_count, toggle=toggle)

--- a/infrared_protocols/codes/nedis/vmat3462at.py
+++ b/infrared_protocols/codes/nedis/vmat3462at.py
@@ -21,7 +21,6 @@ class NedisVMAT3462ATCode(IntEnum):
     B_3 = 0x53
     B_4 = 0x45
 
-
-def make_command(code: NedisVMAT3462ATCode, repeat_count: int = 0) -> Command:
-    """Get the NECCommand for a Nedis VMAT3462AT HDMI switch IR code."""
-    return NECCommand(address=0x0, command=code, repeat_count=repeat_count)
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Get the NECCommand for a Nedis VMAT3462AT HDMI switch IR code."""
+        return NECCommand(address=0x0, command=self.value, repeat_count=repeat_count)

--- a/infrared_protocols/codes/samsung/tv.py
+++ b/infrared_protocols/codes/samsung/tv.py
@@ -49,8 +49,3 @@ class SamsungTVCode(IntEnum):
             command=self.value,
             repeat_count=repeat_count,
         )
-
-
-def make_command(code: SamsungTVCode, repeat_count: int = 0) -> Command:
-    """Build a Samsung32 command for a Samsung TV IR code."""
-    return code.to_command(repeat_count)


### PR DESCRIPTION
Using the enum.to_command() directly is simpler so we can remove make_command().
