### PR TITLE
feat: implement Sony SIRC protocol & add support for PlayStation 2

### DIFF
--- a/infrared_protocols/codes/sony/playstation2.py
+++ b/infrared_protocols/codes/sony/playstation2.py
@@ -1,4 +1,4 @@
-"""Command codes for Sony PlayStation 2 and PSX(DESR-XXXX).
+"""Command codes for Sony PlayStation 2 (SCPH-XXXXX) and PSX (DESR-XXXX).
 
 Based on the following remote control models:
 - SCPH-10150
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from ...commands import Command
-from ...commands.sony import SONYCommand
+from ...commands.sony import SonyCommand
 
 DVD_ADDRESS = 0x1A49
 PS2_ADDRESS = 0x1ADA
@@ -183,7 +183,7 @@ class SonyPlayStation2Code(Enum):
         if self.name.startswith("DESR_"):
             address = _PSX_ADDRESS_BY_SWITCH[psx_switch]
 
-        return SONYCommand(
+        return SonyCommand(
             address=address,
             address_bits=13,
             command=command,

--- a/infrared_protocols/codes/sony/playstation2.py
+++ b/infrared_protocols/codes/sony/playstation2.py
@@ -1,0 +1,390 @@
+"""Command codes for Sony PlayStation 2 and PSX(DESR-XXXX).
+
+Based on the following remote control models:
+- SCPH-10150
+- SCPH-10420
+- RMT-P001
+- RMT-P002J
+
+Supported PS2 models:
+- SCPH-1X000 to SCPH-3X0XX (needs SCPH-10160 IR receiver)
+- SCPH-5X00X
+- SCPH-7X0XX to SCPH-900XX (does not support Open/Close disc tray command)
+- All PSX models (DESR-XXXX, not to be confused with PlayStation 1)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from ...commands import Command
+from ...commands.sony import SONYCommand
+
+DVD_ADDRESS = 0x1A49
+PS2_ADDRESS = 0x1ADA
+PSX_ADDRESS_SWITCH_1 = 0x1A93
+PSX_ADDRESS_SWITCH_2 = 0x1A9B
+PSX_ADDRESS_SWITCH_3 = 0x1AA3
+_PSX_ADDRESS_BY_SWITCH = {
+    1: PSX_ADDRESS_SWITCH_1,
+    2: PSX_ADDRESS_SWITCH_2,
+    3: PSX_ADDRESS_SWITCH_3,
+}
+
+
+class SonyPlayStation2Code(Enum):
+    """Sony PlayStation 2 IR command codes.
+
+    All codes use 20-bit SONY SIRC (address_bits=13).
+
+    DVD playback buttons share address 0x1A49 (device=26, subdevice=73).
+    PS2 console/pad buttons share address 0x1ADA (device=26, subdevice=218).
+    PSX buttons use one of three addresses depending on the remote switch:
+    - switch 1: 0x1A93 (device=26, subdevice=147)
+    - switch 2: 0x1A9B (device=26, subdevice=155)
+    - switch 3: 0x1AA3 (device=26, subdevice=163)
+
+    Values are (address, command) pairs.
+    """
+
+    # DVD playback buttons (not for PSX models)
+    DVD_1 = (DVD_ADDRESS, 0)
+    DVD_2 = (DVD_ADDRESS, 1)
+    DVD_3 = (DVD_ADDRESS, 2)
+    DVD_4 = (DVD_ADDRESS, 3)
+    DVD_5 = (DVD_ADDRESS, 4)
+    DVD_6 = (DVD_ADDRESS, 5)
+    DVD_7 = (DVD_ADDRESS, 6)
+    DVD_8 = (DVD_ADDRESS, 7)
+    DVD_9 = (DVD_ADDRESS, 8)
+    DVD_0 = (DVD_ADDRESS, 9)
+    DVD_ENTER = (DVD_ADDRESS, 11)
+    DVD_RETURN = (DVD_ADDRESS, 14)
+    DVD_CLEAR = (DVD_ADDRESS, 15)
+    DVD_TITLE = (DVD_ADDRESS, 26)
+    DVD_MENU = (DVD_ADDRESS, 27)
+    DVD_PROGRAM = (DVD_ADDRESS, 31)
+    DVD_TIME = (DVD_ADDRESS, 40)
+    DVD_ATOB = (DVD_ADDRESS, 42)
+    DVD_REPEAT = (DVD_ADDRESS, 44)
+    DVD_PREV = (DVD_ADDRESS, 48)
+    DVD_NEXT = (DVD_ADDRESS, 49)
+    DVD_PLAY = (DVD_ADDRESS, 50)
+    DVD_SCAN_BACK = (DVD_ADDRESS, 51)
+    DVD_SCAN_FORW = (DVD_ADDRESS, 52)
+    DVD_SHUFFLE = (DVD_ADDRESS, 53)
+    DVD_STOP = (DVD_ADDRESS, 56)
+    DVD_PAUSE = (DVD_ADDRESS, 57)
+    DVD_DISPLAY = (DVD_ADDRESS, 84)
+    DVD_SLOW_BACK = (DVD_ADDRESS, 96)
+    DVD_SLOW_FORW = (DVD_ADDRESS, 97)
+    DVD_SUBTITLE = (DVD_ADDRESS, 99)
+    DVD_AUDIO = (DVD_ADDRESS, 100)
+    DVD_ANGLE = (DVD_ADDRESS, 101)
+    DVD_UP = (DVD_ADDRESS, 121)
+    DVD_DOWN = (DVD_ADDRESS, 122)
+    DVD_LEFT = (DVD_ADDRESS, 123)
+    DVD_RIGHT = (DVD_ADDRESS, 124)
+
+    # PS2 console/pad buttons (not for PSX models)
+    PS2_POWER = (PS2_ADDRESS, 21)
+    PS2_EJECT = (PS2_ADDRESS, 22)
+    PS2_RESET = (PS2_ADDRESS, 23)
+    PS2_POWER_ON = (PS2_ADDRESS, 46)
+    PS2_POWER_OFF = (PS2_ADDRESS, 47)
+    PS2_SELECT = (PS2_ADDRESS, 80)
+    PS2_L3 = (PS2_ADDRESS, 81)
+    PS2_R3 = (PS2_ADDRESS, 82)
+    PS2_START = (PS2_ADDRESS, 83)
+    PS2_UP = (PS2_ADDRESS, 84)
+    PS2_RIGHT = (PS2_ADDRESS, 85)
+    PS2_DOWN = (PS2_ADDRESS, 86)
+    PS2_LEFT = (PS2_ADDRESS, 87)
+    PS2_L2 = (PS2_ADDRESS, 88)
+    PS2_R2 = (PS2_ADDRESS, 89)
+    PS2_L1 = (PS2_ADDRESS, 90)
+    PS2_R1 = (PS2_ADDRESS, 91)
+    PS2_TRIANGLE = (PS2_ADDRESS, 92)
+    PS2_CIRCLE = (PS2_ADDRESS, 93)
+    PS2_CROSS = (PS2_ADDRESS, 94)
+    PS2_SQUARE = (PS2_ADDRESS, 95)
+    PS2_NO_LIGHT = (PS2_ADDRESS, 117)
+
+    # PSX buttons (not for PS2 models)
+    # - These use the switch-1 address by default; use ``psx_switch`` in
+    #   ``to_command`` to send the same command on switch 2/3 addresses.
+    # - Since analog broadcasting ended on July 24, 2011, some commands are no
+    #   longer relevant.
+    DESR_1 = (PSX_ADDRESS_SWITCH_1, 0)
+    DESR_2 = (PSX_ADDRESS_SWITCH_1, 1)
+    DESR_3 = (PSX_ADDRESS_SWITCH_1, 2)
+    DESR_4 = (PSX_ADDRESS_SWITCH_1, 3)
+    DESR_5 = (PSX_ADDRESS_SWITCH_1, 4)
+    DESR_6 = (PSX_ADDRESS_SWITCH_1, 5)
+    DESR_7 = (PSX_ADDRESS_SWITCH_1, 6)
+    DESR_8 = (PSX_ADDRESS_SWITCH_1, 7)
+    DESR_9 = (PSX_ADDRESS_SWITCH_1, 8)
+    DESR_10 = (PSX_ADDRESS_SWITCH_1, 9)
+    DESR_11 = (PSX_ADDRESS_SWITCH_1, 10)
+    DESR_12 = (PSX_ADDRESS_SWITCH_1, 11)
+    DESR_BS_7 = (PSX_ADDRESS_SWITCH_1, 13)  # Only for RMT-P001
+    DESR_BS_11 = (PSX_ADDRESS_SWITCH_1, 14)  # Only for RMT-P001
+    DESR_CLEAR = (PSX_ADDRESS_SWITCH_1, 15)
+    DESR_POWER = (PSX_ADDRESS_SWITCH_1, 21)
+    DESR_EJECT = (PSX_ADDRESS_SWITCH_1, 22)
+    DESR_STOP = (PSX_ADDRESS_SWITCH_1, 24)
+    DESR_PAUSE = (PSX_ADDRESS_SWITCH_1, 25)
+    DESR_PLAY = (PSX_ADDRESS_SWITCH_1, 26)
+    DESR_RECORD_START = (PSX_ADDRESS_SWITCH_1, 29)
+    DESR_RECORD_PAUSE = (PSX_ADDRESS_SWITCH_1, 30)
+    DESR_RECORD_STOP = (PSX_ADDRESS_SWITCH_1, 31)
+    DESR_DISPLAY = (PSX_ADDRESS_SWITCH_1, 37)
+    DESR_RECORDING_MODE = (PSX_ADDRESS_SWITCH_1, 38)
+    DESR_MENU = (PSX_ADDRESS_SWITCH_1, 41)
+    DESR_PROGRAM = (PSX_ADDRESS_SWITCH_1, 42)
+    DESR_TOP_MENU = (PSX_ADDRESS_SWITCH_1, 44)
+    DESR_G_GUIDE2 = (PSX_ADDRESS_SWITCH_1, 65)  # Only for RMT-P002J
+    DESR_HOME = (PSX_ADDRESS_SWITCH_1, 66)
+    DESR_RETURN = (PSX_ADDRESS_SWITCH_1, 67)
+    DESR_G_GUIDE = (PSX_ADDRESS_SWITCH_1, 69)  # Only for RMT-P001
+    DESR_SELECT = (PSX_ADDRESS_SWITCH_1, 80)
+    DESR_L3 = (PSX_ADDRESS_SWITCH_1, 81)
+    DESR_R3 = (PSX_ADDRESS_SWITCH_1, 82)
+    DESR_START = (PSX_ADDRESS_SWITCH_1, 83)
+    DESR_UP = (PSX_ADDRESS_SWITCH_1, 84)
+    DESR_RIGHT = (PSX_ADDRESS_SWITCH_1, 85)
+    DESR_DOWN = (PSX_ADDRESS_SWITCH_1, 86)
+    DESR_LEFT = (PSX_ADDRESS_SWITCH_1, 87)
+    DESR_L2_SCAN_BACK = (PSX_ADDRESS_SWITCH_1, 88)
+    DESR_R2_SCAN_FORW = (PSX_ADDRESS_SWITCH_1, 89)
+    DESR_L1_PREV = (PSX_ADDRESS_SWITCH_1, 90)
+    DESR_R1_NEXT = (PSX_ADDRESS_SWITCH_1, 91)
+    DESR_TRIANGLE_OPTION = (PSX_ADDRESS_SWITCH_1, 92)
+    DESR_CIRCLE = (PSX_ADDRESS_SWITCH_1, 93)
+    DESR_CROSS_BACK = (PSX_ADDRESS_SWITCH_1, 94)
+    DESR_SQUARE_VIEW = (PSX_ADDRESS_SWITCH_1, 95)
+    DESR_ENTER = (PSX_ADDRESS_SWITCH_1, 96)
+    DESR_QUIT_GAME = (PSX_ADDRESS_SWITCH_1, 97)
+    DESR_DELETE = (PSX_ADDRESS_SWITCH_1, 98)
+    DESR_FLASH_FORW = (PSX_ADDRESS_SWITCH_1, 117)  # Only for RMT-P002J
+    DESR_FLASH_BACK = (PSX_ADDRESS_SWITCH_1, 118)  # Only for RMT-P002J
+
+    def to_command(self, repeat_count: int = 0, *, psx_switch: int = 1) -> Command:
+        """Build a SONY SIRC command for this PlayStation 2/PSX code.
+
+        For DESR codes, set ``psx_switch`` to 1, 2, or 3 to select the
+        corresponding PSX remote switch position address.
+        """
+        if psx_switch not in _PSX_ADDRESS_BY_SWITCH:
+            raise ValueError("psx_switch must be one of 1, 2, or 3")
+
+        address, command = self.value
+        if self.name.startswith("DESR_"):
+            address = _PSX_ADDRESS_BY_SWITCH[psx_switch]
+
+        return SONYCommand(
+            address=address,
+            address_bits=13,
+            command=command,
+            repeat_count=repeat_count,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PlayStation2Model:
+    """A PlayStation 2 / PSX model and the IR codes it accepts."""
+
+    name: str
+    codes: frozenset[SonyPlayStation2Code]
+
+
+# Common code sets reused across models.
+
+_DVD_CODES = frozenset(
+    {
+        SonyPlayStation2Code.DVD_1,
+        SonyPlayStation2Code.DVD_2,
+        SonyPlayStation2Code.DVD_3,
+        SonyPlayStation2Code.DVD_4,
+        SonyPlayStation2Code.DVD_5,
+        SonyPlayStation2Code.DVD_6,
+        SonyPlayStation2Code.DVD_7,
+        SonyPlayStation2Code.DVD_8,
+        SonyPlayStation2Code.DVD_9,
+        SonyPlayStation2Code.DVD_0,
+        SonyPlayStation2Code.DVD_ENTER,
+        SonyPlayStation2Code.DVD_RETURN,
+        SonyPlayStation2Code.DVD_CLEAR,
+        SonyPlayStation2Code.DVD_TITLE,
+        SonyPlayStation2Code.DVD_MENU,
+        SonyPlayStation2Code.DVD_PROGRAM,
+        SonyPlayStation2Code.DVD_TIME,
+        SonyPlayStation2Code.DVD_ATOB,
+        SonyPlayStation2Code.DVD_REPEAT,
+        SonyPlayStation2Code.DVD_PREV,
+        SonyPlayStation2Code.DVD_NEXT,
+        SonyPlayStation2Code.DVD_PLAY,
+        SonyPlayStation2Code.DVD_SCAN_BACK,
+        SonyPlayStation2Code.DVD_SCAN_FORW,
+        SonyPlayStation2Code.DVD_SHUFFLE,
+        SonyPlayStation2Code.DVD_STOP,
+        SonyPlayStation2Code.DVD_PAUSE,
+        SonyPlayStation2Code.DVD_DISPLAY,
+        SonyPlayStation2Code.DVD_SLOW_BACK,
+        SonyPlayStation2Code.DVD_SLOW_FORW,
+        SonyPlayStation2Code.DVD_SUBTITLE,
+        SonyPlayStation2Code.DVD_AUDIO,
+        SonyPlayStation2Code.DVD_ANGLE,
+        SonyPlayStation2Code.DVD_UP,
+        SonyPlayStation2Code.DVD_DOWN,
+        SonyPlayStation2Code.DVD_LEFT,
+        SonyPlayStation2Code.DVD_RIGHT,
+    }
+)
+
+_PS2_CODES = frozenset(
+    {
+        SonyPlayStation2Code.PS2_POWER,
+        SonyPlayStation2Code.PS2_EJECT,
+        SonyPlayStation2Code.PS2_RESET,
+        SonyPlayStation2Code.PS2_POWER_ON,
+        SonyPlayStation2Code.PS2_POWER_OFF,
+        SonyPlayStation2Code.PS2_NO_LIGHT,
+        SonyPlayStation2Code.PS2_SELECT,
+        SonyPlayStation2Code.PS2_L3,
+        SonyPlayStation2Code.PS2_R3,
+        SonyPlayStation2Code.PS2_START,
+        SonyPlayStation2Code.PS2_UP,
+        SonyPlayStation2Code.PS2_RIGHT,
+        SonyPlayStation2Code.PS2_DOWN,
+        SonyPlayStation2Code.PS2_LEFT,
+        SonyPlayStation2Code.PS2_L2,
+        SonyPlayStation2Code.PS2_R2,
+        SonyPlayStation2Code.PS2_L1,
+        SonyPlayStation2Code.PS2_R1,
+        SonyPlayStation2Code.PS2_TRIANGLE,
+        SonyPlayStation2Code.PS2_CIRCLE,
+        SonyPlayStation2Code.PS2_CROSS,
+        SonyPlayStation2Code.PS2_SQUARE,
+    }
+)
+
+_DESR_COMMON_CODES = frozenset(
+    {
+        SonyPlayStation2Code.DESR_EJECT,
+        SonyPlayStation2Code.DESR_QUIT_GAME,
+        SonyPlayStation2Code.DESR_POWER,
+        SonyPlayStation2Code.DESR_1,
+        SonyPlayStation2Code.DESR_2,
+        SonyPlayStation2Code.DESR_3,
+        SonyPlayStation2Code.DESR_4,
+        SonyPlayStation2Code.DESR_5,
+        SonyPlayStation2Code.DESR_6,
+        SonyPlayStation2Code.DESR_7,
+        SonyPlayStation2Code.DESR_8,
+        SonyPlayStation2Code.DESR_9,
+        SonyPlayStation2Code.DESR_10,
+        SonyPlayStation2Code.DESR_11,
+        SonyPlayStation2Code.DESR_12,
+        SonyPlayStation2Code.DESR_CLEAR,
+        SonyPlayStation2Code.DESR_TOP_MENU,
+        SonyPlayStation2Code.DESR_MENU,
+        SonyPlayStation2Code.DESR_RETURN,
+        SonyPlayStation2Code.DESR_TRIANGLE_OPTION,
+        SonyPlayStation2Code.DESR_CIRCLE,
+        SonyPlayStation2Code.DESR_SQUARE_VIEW,
+        SonyPlayStation2Code.DESR_CROSS_BACK,
+        SonyPlayStation2Code.DESR_UP,
+        SonyPlayStation2Code.DESR_LEFT,
+        SonyPlayStation2Code.DESR_RIGHT,
+        SonyPlayStation2Code.DESR_DOWN,
+        SonyPlayStation2Code.DESR_ENTER,
+        SonyPlayStation2Code.DESR_PROGRAM,
+        SonyPlayStation2Code.DESR_HOME,
+        SonyPlayStation2Code.DESR_DISPLAY,
+        SonyPlayStation2Code.DESR_L1_PREV,
+        SonyPlayStation2Code.DESR_L3,
+        SonyPlayStation2Code.DESR_R3,
+        SonyPlayStation2Code.DESR_R1_NEXT,
+        SonyPlayStation2Code.DESR_L2_SCAN_BACK,
+        SonyPlayStation2Code.DESR_SELECT,
+        SonyPlayStation2Code.DESR_START,
+        SonyPlayStation2Code.DESR_R2_SCAN_FORW,
+        SonyPlayStation2Code.DESR_PLAY,
+        SonyPlayStation2Code.DESR_PAUSE,
+        SonyPlayStation2Code.DESR_STOP,
+        SonyPlayStation2Code.DESR_RECORDING_MODE,
+        SonyPlayStation2Code.DESR_RECORD_START,
+        SonyPlayStation2Code.DESR_RECORD_PAUSE,
+        SonyPlayStation2Code.DESR_RECORD_STOP,
+        SonyPlayStation2Code.DESR_DELETE,
+    }
+)
+
+_DESR_P001_ONLY_CODES = frozenset(
+    {
+        SonyPlayStation2Code.DESR_G_GUIDE,
+        SonyPlayStation2Code.DESR_BS_7,
+        SonyPlayStation2Code.DESR_BS_11,
+    }
+)
+
+_DESR_P002J_ONLY_CODES = frozenset(
+    {
+        SonyPlayStation2Code.DESR_G_GUIDE2,
+        SonyPlayStation2Code.DESR_FLASH_BACK,
+        SonyPlayStation2Code.DESR_FLASH_FORW,
+    }
+)
+
+
+PS2_FAT_WITHOUT_IR_MODELS = PlayStation2Model(
+    name="PS2 Fat model without IR (SCPH-1X000 to SCPH-3X0XX, needs IR receiver)",
+    codes=(_DVD_CODES | _PS2_CODES)
+    - frozenset(
+        {
+            SonyPlayStation2Code.PS2_POWER,
+            SonyPlayStation2Code.PS2_EJECT,
+            SonyPlayStation2Code.PS2_RESET,
+            SonyPlayStation2Code.PS2_POWER_ON,
+            SonyPlayStation2Code.PS2_POWER_OFF,
+            SonyPlayStation2Code.PS2_NO_LIGHT,
+        }
+    ),
+)
+
+PS2_FAT_WITH_IR_MODELS = PlayStation2Model(
+    name="PS2 Fat model with IR (SCPH-5X00X)",
+    codes=_DVD_CODES | _PS2_CODES
+)
+
+PS2_SLIM_MODELS = PlayStation2Model(
+    name="PS2 Slim models (SCPH-7X0XX to SCPH-900XX)",
+    codes=PS2_FAT_WITH_IR_MODELS.codes
+    - frozenset(
+        {
+            SonyPlayStation2Code.PS2_EJECT,
+        }
+    ),
+)
+
+PSX_EARLIER_MODELS = PlayStation2Model(
+    name="PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100)",
+    codes=_DESR_COMMON_CODES | _DESR_P001_ONLY_CODES,
+)
+
+PSX_LATER_MODELS = PlayStation2Model(
+    name="PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700)",
+    codes=_DESR_COMMON_CODES | _DESR_P002J_ONLY_CODES,
+)
+
+
+#: All known PlayStation 2 / PSX model groups, for iteration.
+ALL_MODELS: tuple[PlayStation2Model, ...] = (
+    PS2_FAT_WITHOUT_IR_MODELS,
+    PS2_FAT_WITH_IR_MODELS,
+    PS2_SLIM_MODELS,
+    PSX_EARLIER_MODELS,
+    PSX_LATER_MODELS,
+)

--- a/infrared_protocols/codes/sony/playstation2.py
+++ b/infrared_protocols/codes/sony/playstation2.py
@@ -1,16 +1,15 @@
-"""Command codes for Sony PlayStation 2 (SCPH-XXXXX) and PSX (DESR-XXXX).
+"""Command codes for Sony PlayStation 2 (SCPH-XXXXX).
 
 Based on the following remote control models:
 - SCPH-10150
 - SCPH-10420
-- RMT-P001
-- RMT-P002J
 
 Supported PS2 models:
 - SCPH-1X000 to SCPH-3X0XX (needs SCPH-10160 IR receiver)
 - SCPH-5X00X
 - SCPH-7X0XX to SCPH-900XX (does not support Open/Close disc tray command)
-- All PSX models (DESR-XXXX, not to be confused with PlayStation 1)
+
+For PSX (DESR-XXXX) models, see psx.py.
 """
 
 from __future__ import annotations
@@ -21,16 +20,8 @@ from enum import Enum
 from ...commands import Command
 from ...commands.sony import SonyCommand
 
-DVD_ADDRESS = 0x1A49
-PS2_ADDRESS = 0x1ADA
-PSX_ADDRESS_SWITCH_1 = 0x1A93
-PSX_ADDRESS_SWITCH_2 = 0x1A9B
-PSX_ADDRESS_SWITCH_3 = 0x1AA3
-_PSX_ADDRESS_BY_SWITCH = {
-    1: PSX_ADDRESS_SWITCH_1,
-    2: PSX_ADDRESS_SWITCH_2,
-    3: PSX_ADDRESS_SWITCH_3,
-}
+_DVD_ADDRESS = 0x1A49
+_PS2_ADDRESS = 0x1ADA
 
 
 class SonyPlayStation2Code(Enum):
@@ -40,148 +31,76 @@ class SonyPlayStation2Code(Enum):
 
     DVD playback buttons share address 0x1A49 (device=26, subdevice=73).
     PS2 console/pad buttons share address 0x1ADA (device=26, subdevice=218).
-    PSX buttons use one of three addresses depending on the remote switch:
-    - switch 1: 0x1A93 (device=26, subdevice=147)
-    - switch 2: 0x1A9B (device=26, subdevice=155)
-    - switch 3: 0x1AA3 (device=26, subdevice=163)
 
     Values are (address, command) pairs.
     """
 
     # DVD playback buttons (not for PSX models)
-    DVD_1 = (DVD_ADDRESS, 0)
-    DVD_2 = (DVD_ADDRESS, 1)
-    DVD_3 = (DVD_ADDRESS, 2)
-    DVD_4 = (DVD_ADDRESS, 3)
-    DVD_5 = (DVD_ADDRESS, 4)
-    DVD_6 = (DVD_ADDRESS, 5)
-    DVD_7 = (DVD_ADDRESS, 6)
-    DVD_8 = (DVD_ADDRESS, 7)
-    DVD_9 = (DVD_ADDRESS, 8)
-    DVD_0 = (DVD_ADDRESS, 9)
-    DVD_ENTER = (DVD_ADDRESS, 11)
-    DVD_RETURN = (DVD_ADDRESS, 14)
-    DVD_CLEAR = (DVD_ADDRESS, 15)
-    DVD_TITLE = (DVD_ADDRESS, 26)
-    DVD_MENU = (DVD_ADDRESS, 27)
-    DVD_PROGRAM = (DVD_ADDRESS, 31)
-    DVD_TIME = (DVD_ADDRESS, 40)
-    DVD_ATOB = (DVD_ADDRESS, 42)
-    DVD_REPEAT = (DVD_ADDRESS, 44)
-    DVD_PREV = (DVD_ADDRESS, 48)
-    DVD_NEXT = (DVD_ADDRESS, 49)
-    DVD_PLAY = (DVD_ADDRESS, 50)
-    DVD_SCAN_BACK = (DVD_ADDRESS, 51)
-    DVD_SCAN_FORW = (DVD_ADDRESS, 52)
-    DVD_SHUFFLE = (DVD_ADDRESS, 53)
-    DVD_STOP = (DVD_ADDRESS, 56)
-    DVD_PAUSE = (DVD_ADDRESS, 57)
-    DVD_DISPLAY = (DVD_ADDRESS, 84)
-    DVD_SLOW_BACK = (DVD_ADDRESS, 96)
-    DVD_SLOW_FORW = (DVD_ADDRESS, 97)
-    DVD_SUBTITLE = (DVD_ADDRESS, 99)
-    DVD_AUDIO = (DVD_ADDRESS, 100)
-    DVD_ANGLE = (DVD_ADDRESS, 101)
-    DVD_UP = (DVD_ADDRESS, 121)
-    DVD_DOWN = (DVD_ADDRESS, 122)
-    DVD_LEFT = (DVD_ADDRESS, 123)
-    DVD_RIGHT = (DVD_ADDRESS, 124)
+    DVD_1 = (_DVD_ADDRESS, 0)
+    DVD_2 = (_DVD_ADDRESS, 1)
+    DVD_3 = (_DVD_ADDRESS, 2)
+    DVD_4 = (_DVD_ADDRESS, 3)
+    DVD_5 = (_DVD_ADDRESS, 4)
+    DVD_6 = (_DVD_ADDRESS, 5)
+    DVD_7 = (_DVD_ADDRESS, 6)
+    DVD_8 = (_DVD_ADDRESS, 7)
+    DVD_9 = (_DVD_ADDRESS, 8)
+    DVD_0 = (_DVD_ADDRESS, 9)
+    DVD_ENTER = (_DVD_ADDRESS, 11)
+    DVD_RETURN = (_DVD_ADDRESS, 14)
+    DVD_CLEAR = (_DVD_ADDRESS, 15)
+    DVD_TITLE = (_DVD_ADDRESS, 26)
+    DVD_MENU = (_DVD_ADDRESS, 27)
+    DVD_PROGRAM = (_DVD_ADDRESS, 31)
+    DVD_TIME = (_DVD_ADDRESS, 40)
+    DVD_ATOB = (_DVD_ADDRESS, 42)
+    DVD_REPEAT = (_DVD_ADDRESS, 44)
+    DVD_PREV = (_DVD_ADDRESS, 48)
+    DVD_NEXT = (_DVD_ADDRESS, 49)
+    DVD_PLAY = (_DVD_ADDRESS, 50)
+    DVD_SCAN_BACK = (_DVD_ADDRESS, 51)
+    DVD_SCAN_FORW = (_DVD_ADDRESS, 52)
+    DVD_SHUFFLE = (_DVD_ADDRESS, 53)
+    DVD_STOP = (_DVD_ADDRESS, 56)
+    DVD_PAUSE = (_DVD_ADDRESS, 57)
+    DVD_DISPLAY = (_DVD_ADDRESS, 84)
+    DVD_SLOW_BACK = (_DVD_ADDRESS, 96)
+    DVD_SLOW_FORW = (_DVD_ADDRESS, 97)
+    DVD_SUBTITLE = (_DVD_ADDRESS, 99)
+    DVD_AUDIO = (_DVD_ADDRESS, 100)
+    DVD_ANGLE = (_DVD_ADDRESS, 101)
+    DVD_UP = (_DVD_ADDRESS, 121)
+    DVD_DOWN = (_DVD_ADDRESS, 122)
+    DVD_LEFT = (_DVD_ADDRESS, 123)
+    DVD_RIGHT = (_DVD_ADDRESS, 124)
 
     # PS2 console/pad buttons (not for PSX models)
-    PS2_POWER = (PS2_ADDRESS, 21)
-    PS2_EJECT = (PS2_ADDRESS, 22)
-    PS2_RESET = (PS2_ADDRESS, 23)
-    PS2_POWER_ON = (PS2_ADDRESS, 46)
-    PS2_POWER_OFF = (PS2_ADDRESS, 47)
-    PS2_SELECT = (PS2_ADDRESS, 80)
-    PS2_L3 = (PS2_ADDRESS, 81)
-    PS2_R3 = (PS2_ADDRESS, 82)
-    PS2_START = (PS2_ADDRESS, 83)
-    PS2_UP = (PS2_ADDRESS, 84)
-    PS2_RIGHT = (PS2_ADDRESS, 85)
-    PS2_DOWN = (PS2_ADDRESS, 86)
-    PS2_LEFT = (PS2_ADDRESS, 87)
-    PS2_L2 = (PS2_ADDRESS, 88)
-    PS2_R2 = (PS2_ADDRESS, 89)
-    PS2_L1 = (PS2_ADDRESS, 90)
-    PS2_R1 = (PS2_ADDRESS, 91)
-    PS2_TRIANGLE = (PS2_ADDRESS, 92)
-    PS2_CIRCLE = (PS2_ADDRESS, 93)
-    PS2_CROSS = (PS2_ADDRESS, 94)
-    PS2_SQUARE = (PS2_ADDRESS, 95)
-    PS2_NO_LIGHT = (PS2_ADDRESS, 117)
+    PS2_POWER = (_PS2_ADDRESS, 21)
+    PS2_EJECT = (_PS2_ADDRESS, 22)
+    PS2_RESET = (_PS2_ADDRESS, 23)
+    PS2_POWER_ON = (_PS2_ADDRESS, 46)
+    PS2_POWER_OFF = (_PS2_ADDRESS, 47)
+    PS2_SELECT = (_PS2_ADDRESS, 80)
+    PS2_L3 = (_PS2_ADDRESS, 81)
+    PS2_R3 = (_PS2_ADDRESS, 82)
+    PS2_START = (_PS2_ADDRESS, 83)
+    PS2_UP = (_PS2_ADDRESS, 84)
+    PS2_RIGHT = (_PS2_ADDRESS, 85)
+    PS2_DOWN = (_PS2_ADDRESS, 86)
+    PS2_LEFT = (_PS2_ADDRESS, 87)
+    PS2_L2 = (_PS2_ADDRESS, 88)
+    PS2_R2 = (_PS2_ADDRESS, 89)
+    PS2_L1 = (_PS2_ADDRESS, 90)
+    PS2_R1 = (_PS2_ADDRESS, 91)
+    PS2_TRIANGLE = (_PS2_ADDRESS, 92)
+    PS2_CIRCLE = (_PS2_ADDRESS, 93)
+    PS2_CROSS = (_PS2_ADDRESS, 94)
+    PS2_SQUARE = (_PS2_ADDRESS, 95)
+    PS2_NO_LIGHT = (_PS2_ADDRESS, 117)
 
-    # PSX buttons (not for PS2 models)
-    # - These use the switch-1 address by default; use ``psx_switch`` in
-    #   ``to_command`` to send the same command on switch 2/3 addresses.
-    # - Since analog broadcasting ended on July 24, 2011, some commands are no
-    #   longer relevant.
-    DESR_1 = (PSX_ADDRESS_SWITCH_1, 0)
-    DESR_2 = (PSX_ADDRESS_SWITCH_1, 1)
-    DESR_3 = (PSX_ADDRESS_SWITCH_1, 2)
-    DESR_4 = (PSX_ADDRESS_SWITCH_1, 3)
-    DESR_5 = (PSX_ADDRESS_SWITCH_1, 4)
-    DESR_6 = (PSX_ADDRESS_SWITCH_1, 5)
-    DESR_7 = (PSX_ADDRESS_SWITCH_1, 6)
-    DESR_8 = (PSX_ADDRESS_SWITCH_1, 7)
-    DESR_9 = (PSX_ADDRESS_SWITCH_1, 8)
-    DESR_10 = (PSX_ADDRESS_SWITCH_1, 9)
-    DESR_11 = (PSX_ADDRESS_SWITCH_1, 10)
-    DESR_12 = (PSX_ADDRESS_SWITCH_1, 11)
-    DESR_BS_7 = (PSX_ADDRESS_SWITCH_1, 13)  # Only for RMT-P001
-    DESR_BS_11 = (PSX_ADDRESS_SWITCH_1, 14)  # Only for RMT-P001
-    DESR_CLEAR = (PSX_ADDRESS_SWITCH_1, 15)
-    DESR_POWER = (PSX_ADDRESS_SWITCH_1, 21)
-    DESR_EJECT = (PSX_ADDRESS_SWITCH_1, 22)
-    DESR_STOP = (PSX_ADDRESS_SWITCH_1, 24)
-    DESR_PAUSE = (PSX_ADDRESS_SWITCH_1, 25)
-    DESR_PLAY = (PSX_ADDRESS_SWITCH_1, 26)
-    DESR_RECORD_START = (PSX_ADDRESS_SWITCH_1, 29)
-    DESR_RECORD_PAUSE = (PSX_ADDRESS_SWITCH_1, 30)
-    DESR_RECORD_STOP = (PSX_ADDRESS_SWITCH_1, 31)
-    DESR_DISPLAY = (PSX_ADDRESS_SWITCH_1, 37)
-    DESR_RECORDING_MODE = (PSX_ADDRESS_SWITCH_1, 38)
-    DESR_MENU = (PSX_ADDRESS_SWITCH_1, 41)
-    DESR_PROGRAM = (PSX_ADDRESS_SWITCH_1, 42)
-    DESR_TOP_MENU = (PSX_ADDRESS_SWITCH_1, 44)
-    DESR_G_GUIDE2 = (PSX_ADDRESS_SWITCH_1, 65)  # Only for RMT-P002J
-    DESR_HOME = (PSX_ADDRESS_SWITCH_1, 66)
-    DESR_RETURN = (PSX_ADDRESS_SWITCH_1, 67)
-    DESR_G_GUIDE = (PSX_ADDRESS_SWITCH_1, 69)  # Only for RMT-P001
-    DESR_SELECT = (PSX_ADDRESS_SWITCH_1, 80)
-    DESR_L3 = (PSX_ADDRESS_SWITCH_1, 81)
-    DESR_R3 = (PSX_ADDRESS_SWITCH_1, 82)
-    DESR_START = (PSX_ADDRESS_SWITCH_1, 83)
-    DESR_UP = (PSX_ADDRESS_SWITCH_1, 84)
-    DESR_RIGHT = (PSX_ADDRESS_SWITCH_1, 85)
-    DESR_DOWN = (PSX_ADDRESS_SWITCH_1, 86)
-    DESR_LEFT = (PSX_ADDRESS_SWITCH_1, 87)
-    DESR_L2_SCAN_BACK = (PSX_ADDRESS_SWITCH_1, 88)
-    DESR_R2_SCAN_FORW = (PSX_ADDRESS_SWITCH_1, 89)
-    DESR_L1_PREV = (PSX_ADDRESS_SWITCH_1, 90)
-    DESR_R1_NEXT = (PSX_ADDRESS_SWITCH_1, 91)
-    DESR_TRIANGLE_OPTION = (PSX_ADDRESS_SWITCH_1, 92)
-    DESR_CIRCLE = (PSX_ADDRESS_SWITCH_1, 93)
-    DESR_CROSS_BACK = (PSX_ADDRESS_SWITCH_1, 94)
-    DESR_SQUARE_VIEW = (PSX_ADDRESS_SWITCH_1, 95)
-    DESR_ENTER = (PSX_ADDRESS_SWITCH_1, 96)
-    DESR_QUIT_GAME = (PSX_ADDRESS_SWITCH_1, 97)
-    DESR_DELETE = (PSX_ADDRESS_SWITCH_1, 98)
-    DESR_FLASH_FORW = (PSX_ADDRESS_SWITCH_1, 117)  # Only for RMT-P002J
-    DESR_FLASH_BACK = (PSX_ADDRESS_SWITCH_1, 118)  # Only for RMT-P002J
-
-    def to_command(self, *, psx_switch: int = 1) -> Command:
-        """Build a SONY SIRC command for this PlayStation 2/PSX code.
-
-        For DESR codes, set ``psx_switch`` to 1, 2, or 3 to select the
-        corresponding PSX remote switch position address.
-        """
-        if psx_switch not in _PSX_ADDRESS_BY_SWITCH:
-            raise ValueError("psx_switch must be one of 1, 2, or 3")
-
+    def to_command(self) -> Command:
+        """Build a SONY SIRC command for this PlayStation 2 code."""
         address, command = self.value
-        if self.name.startswith("DESR_"):
-            address = _PSX_ADDRESS_BY_SWITCH[psx_switch]
 
         return SonyCommand(
             address=address,
@@ -192,7 +111,7 @@ class SonyPlayStation2Code(Enum):
 
 @dataclass(frozen=True, slots=True)
 class PlayStation2Model:
-    """A PlayStation 2 / PSX model and the IR codes it accepts."""
+    """A PlayStation 2 model and the IR codes it accepts."""
 
     name: str
     codes: frozenset[SonyPlayStation2Code]
@@ -269,75 +188,6 @@ _PS2_CODES = frozenset(
     }
 )
 
-_DESR_COMMON_CODES = frozenset(
-    {
-        SonyPlayStation2Code.DESR_EJECT,
-        SonyPlayStation2Code.DESR_QUIT_GAME,
-        SonyPlayStation2Code.DESR_POWER,
-        SonyPlayStation2Code.DESR_1,
-        SonyPlayStation2Code.DESR_2,
-        SonyPlayStation2Code.DESR_3,
-        SonyPlayStation2Code.DESR_4,
-        SonyPlayStation2Code.DESR_5,
-        SonyPlayStation2Code.DESR_6,
-        SonyPlayStation2Code.DESR_7,
-        SonyPlayStation2Code.DESR_8,
-        SonyPlayStation2Code.DESR_9,
-        SonyPlayStation2Code.DESR_10,
-        SonyPlayStation2Code.DESR_11,
-        SonyPlayStation2Code.DESR_12,
-        SonyPlayStation2Code.DESR_CLEAR,
-        SonyPlayStation2Code.DESR_TOP_MENU,
-        SonyPlayStation2Code.DESR_MENU,
-        SonyPlayStation2Code.DESR_RETURN,
-        SonyPlayStation2Code.DESR_TRIANGLE_OPTION,
-        SonyPlayStation2Code.DESR_CIRCLE,
-        SonyPlayStation2Code.DESR_SQUARE_VIEW,
-        SonyPlayStation2Code.DESR_CROSS_BACK,
-        SonyPlayStation2Code.DESR_UP,
-        SonyPlayStation2Code.DESR_LEFT,
-        SonyPlayStation2Code.DESR_RIGHT,
-        SonyPlayStation2Code.DESR_DOWN,
-        SonyPlayStation2Code.DESR_ENTER,
-        SonyPlayStation2Code.DESR_PROGRAM,
-        SonyPlayStation2Code.DESR_HOME,
-        SonyPlayStation2Code.DESR_DISPLAY,
-        SonyPlayStation2Code.DESR_L1_PREV,
-        SonyPlayStation2Code.DESR_L3,
-        SonyPlayStation2Code.DESR_R3,
-        SonyPlayStation2Code.DESR_R1_NEXT,
-        SonyPlayStation2Code.DESR_L2_SCAN_BACK,
-        SonyPlayStation2Code.DESR_SELECT,
-        SonyPlayStation2Code.DESR_START,
-        SonyPlayStation2Code.DESR_R2_SCAN_FORW,
-        SonyPlayStation2Code.DESR_PLAY,
-        SonyPlayStation2Code.DESR_PAUSE,
-        SonyPlayStation2Code.DESR_STOP,
-        SonyPlayStation2Code.DESR_RECORDING_MODE,
-        SonyPlayStation2Code.DESR_RECORD_START,
-        SonyPlayStation2Code.DESR_RECORD_PAUSE,
-        SonyPlayStation2Code.DESR_RECORD_STOP,
-        SonyPlayStation2Code.DESR_DELETE,
-    }
-)
-
-_DESR_P001_ONLY_CODES = frozenset(
-    {
-        SonyPlayStation2Code.DESR_G_GUIDE,
-        SonyPlayStation2Code.DESR_BS_7,
-        SonyPlayStation2Code.DESR_BS_11,
-    }
-)
-
-_DESR_P002J_ONLY_CODES = frozenset(
-    {
-        SonyPlayStation2Code.DESR_G_GUIDE2,
-        SonyPlayStation2Code.DESR_FLASH_BACK,
-        SonyPlayStation2Code.DESR_FLASH_FORW,
-    }
-)
-
-
 PS2_FAT_WITHOUT_IR_MODELS = PlayStation2Model(
     name="PS2 Fat model without IR (SCPH-1X000 to SCPH-3X0XX, needs IR receiver)",
     codes=(_DVD_CODES | _PS2_CODES)
@@ -354,8 +204,7 @@ PS2_FAT_WITHOUT_IR_MODELS = PlayStation2Model(
 )
 
 PS2_FAT_WITH_IR_MODELS = PlayStation2Model(
-    name="PS2 Fat model with IR (SCPH-5X00X)",
-    codes=_DVD_CODES | _PS2_CODES
+    name="PS2 Fat model with IR (SCPH-5X00X)", codes=_DVD_CODES | _PS2_CODES
 )
 
 PS2_SLIM_MODELS = PlayStation2Model(
@@ -366,24 +215,4 @@ PS2_SLIM_MODELS = PlayStation2Model(
             SonyPlayStation2Code.PS2_EJECT,
         }
     ),
-)
-
-PSX_EARLIER_MODELS = PlayStation2Model(
-    name="PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100)",
-    codes=_DESR_COMMON_CODES | _DESR_P001_ONLY_CODES,
-)
-
-PSX_LATER_MODELS = PlayStation2Model(
-    name="PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700)",
-    codes=_DESR_COMMON_CODES | _DESR_P002J_ONLY_CODES,
-)
-
-
-#: All known PlayStation 2 / PSX model groups, for iteration.
-ALL_MODELS: tuple[PlayStation2Model, ...] = (
-    PS2_FAT_WITHOUT_IR_MODELS,
-    PS2_FAT_WITH_IR_MODELS,
-    PS2_SLIM_MODELS,
-    PSX_EARLIER_MODELS,
-    PSX_LATER_MODELS,
 )

--- a/infrared_protocols/codes/sony/playstation2.py
+++ b/infrared_protocols/codes/sony/playstation2.py
@@ -170,7 +170,7 @@ class SonyPlayStation2Code(Enum):
     DESR_FLASH_FORW = (PSX_ADDRESS_SWITCH_1, 117)  # Only for RMT-P002J
     DESR_FLASH_BACK = (PSX_ADDRESS_SWITCH_1, 118)  # Only for RMT-P002J
 
-    def to_command(self, repeat_count: int = 0, *, psx_switch: int = 1) -> Command:
+    def to_command(self, *, psx_switch: int = 1) -> Command:
         """Build a SONY SIRC command for this PlayStation 2/PSX code.
 
         For DESR codes, set ``psx_switch`` to 1, 2, or 3 to select the
@@ -187,7 +187,6 @@ class SonyPlayStation2Code(Enum):
             address=address,
             address_bits=13,
             command=command,
-            repeat_count=repeat_count,
         )
 
 

--- a/infrared_protocols/codes/sony/psx.py
+++ b/infrared_protocols/codes/sony/psx.py
@@ -21,293 +21,94 @@ from enum import Enum
 from ...commands import Command
 from ...commands.sony import SonyCommand
 
-_ADDRESS_SWITCH_1 = 0x1A93
-_ADDRESS_SWITCH_2 = 0x1A9B
-_ADDRESS_SWITCH_3 = 0x1AA3
-
-# region Command code values
-_CMD_1 = 0
-_CMD_2 = 1
-_CMD_3 = 2
-_CMD_4 = 3
-_CMD_5 = 4
-_CMD_6 = 5
-_CMD_7 = 6
-_CMD_8 = 7
-_CMD_9 = 8
-_CMD_10 = 9
-_CMD_11 = 10
-_CMD_12 = 11
-_CMD_BS_7 = 13  # RMT-P001 only
-_CMD_BS_11 = 14  # RMT-P001 only
-_CMD_CLEAR = 15
-_CMD_POWER = 21
-_CMD_EJECT = 22
-_CMD_STOP = 24
-_CMD_PAUSE = 25
-_CMD_PLAY = 26
-_CMD_RECORD_START = 29
-_CMD_RECORD_PAUSE = 30
-_CMD_RECORD_STOP = 31
-_CMD_DISPLAY = 37
-_CMD_RECORDING_MODE = 38
-_CMD_MENU = 41
-_CMD_PROGRAM = 42
-_CMD_TOP_MENU = 44
-_CMD_G_GUIDE2 = 65  # RMT-P002J only
-_CMD_HOME = 66
-_CMD_RETURN = 67
-_CMD_G_GUIDE = 69  # RMT-P001 only
-_CMD_SELECT = 80
-_CMD_L3 = 81
-_CMD_R3 = 82
-_CMD_START = 83
-_CMD_UP = 84
-_CMD_RIGHT = 85
-_CMD_DOWN = 86
-_CMD_LEFT = 87
-_CMD_L2_SCAN_BACK = 88
-_CMD_R2_SCAN_FORW = 89
-_CMD_L1_PREV = 90
-_CMD_R1_NEXT = 91
-_CMD_TRIANGLE_OPTION = 92
-_CMD_CIRCLE = 93
-_CMD_CROSS_BACK = 94
-_CMD_SQUARE_VIEW = 95
-_CMD_ENTER = 96
-_CMD_QUIT_GAME = 97
-_CMD_DELETE = 98
-_CMD_FLASH_FORW = 117  # RMT-P002J only
-_CMD_FLASH_BACK = 118  # RMT-P002J only
-# endregion Command code values
-
-# Code grouping by remote model
-_P001_ONLY_COMMANDS = frozenset(
-    [
-        _CMD_G_GUIDE,
-        _CMD_BS_7,
-        _CMD_BS_11,
-    ]
-)
-
-_P002J_ONLY_COMMANDS = frozenset(
-    [
-        _CMD_G_GUIDE2,
-        _CMD_FLASH_FORW,
-        _CMD_FLASH_BACK,
-    ]
-)
+_SWITCH_TO_ADDRESS = {
+    1: 0x1A93,
+    2: 0x1A9B,
+    3: 0x1AA3,
+}
 
 
-class _PSXSwitchCodeMixin:
-    """Non-Enum mixin providing to_command() for PSX DIP-switch code enums.
+class SonyPSXCode(Enum):
+    """Sony PSX IR command codes.
 
-    Values in the concrete Enum subclasses are (address, command) pairs.
+    All codes use 20-bit SONY SIRC (address_bits=13).
+
+    address:
+    - 0x1A93: switch position 1
+    - 0x1A9B: switch position 2
+    - 0x1AA3: switch position 3
     """
 
-    def to_command(self) -> Command:
-        """Build a SONY SIRC command for this PSX code."""
-        address, command = self.value  # type: ignore[attr-defined]
+    NUM_1 = 0
+    NUM_2 = 1
+    NUM_3 = 2
+    NUM_4 = 3
+    NUM_5 = 4
+    NUM_6 = 5
+    NUM_7 = 6
+    NUM_8 = 7
+    NUM_9 = 8
+    NUM_10 = 9
+    NUM_11 = 10
+    NUM_12 = 11
+    BS_7 = 13  # RMT-P001 only
+    BS_11 = 14  # RMT-P001 only
+    CLEAR = 15
+    POWER = 21
+    EJECT = 22
+    STOP = 24
+    PAUSE = 25
+    PLAY = 26
+    RECORD_START = 29
+    RECORD_PAUSE = 30
+    RECORD_STOP = 31
+    DISPLAY = 37
+    RECORDING_MODE = 38
+    MENU = 41
+    PROGRAM = 42
+    TOP_MENU = 44
+    G_GUIDE2 = 65  # RMT-P002J only
+    HOME = 66
+    RETURN = 67
+    G_GUIDE = 69  # RMT-P001 only
+    SELECT = 80
+    L3 = 81
+    R3 = 82
+    START = 83
+    UP = 84
+    RIGHT = 85
+    DOWN = 86
+    LEFT = 87
+    L2_SCAN_BACK = 88
+    R2_SCAN_FORW = 89
+    L1_PREV = 90
+    R1_NEXT = 91
+    TRIANGLE_OPTION = 92
+    CIRCLE = 93
+    CROSS_BACK = 94
+    SQUARE_VIEW = 95
+    ENTER = 96
+    QUIT_GAME = 97
+    DELETE = 98
+    FLASH_FORW = 117  # RMT-P002J only
+    FLASH_BACK = 118  # RMT-P002J only
+
+    def to_command(self, switch: int = 1) -> Command:
+        """Build a SONY SIRC command for this PSX code.
+
+        :param switch: The switch position on the PSX remote receiver unit (1, 2, or 3).
+            Each position maps to a distinct IR address, allowing multiple PSX units
+            to be controlled independently in the same room. Defaults to 1.
+        """
+        if switch not in _SWITCH_TO_ADDRESS.keys():
+            raise ValueError(f"Invalid switch position: {switch}")
+
+        command = self.value
         return SonyCommand(
-            address=address,
+            address=_SWITCH_TO_ADDRESS[switch],
             address_bits=13,
             command=command,
         )
-
-
-class SonyPSXSwitch1Code(_PSXSwitchCodeMixin, Enum):
-    """Sony PSX (remote switch 1) IR command codes.
-
-    All codes use 20-bit SONY SIRC (address_bits=13).
-
-    address is 0x1A93 for switch position 1.
-
-    Values are (address, command) pairs.
-    """
-
-    NUM_1 = (_ADDRESS_SWITCH_1, _CMD_1)
-    NUM_2 = (_ADDRESS_SWITCH_1, _CMD_2)
-    NUM_3 = (_ADDRESS_SWITCH_1, _CMD_3)
-    NUM_4 = (_ADDRESS_SWITCH_1, _CMD_4)
-    NUM_5 = (_ADDRESS_SWITCH_1, _CMD_5)
-    NUM_6 = (_ADDRESS_SWITCH_1, _CMD_6)
-    NUM_7 = (_ADDRESS_SWITCH_1, _CMD_7)
-    NUM_8 = (_ADDRESS_SWITCH_1, _CMD_8)
-    NUM_9 = (_ADDRESS_SWITCH_1, _CMD_9)
-    NUM_10 = (_ADDRESS_SWITCH_1, _CMD_10)
-    NUM_11 = (_ADDRESS_SWITCH_1, _CMD_11)
-    NUM_12 = (_ADDRESS_SWITCH_1, _CMD_12)
-    BS_7 = (_ADDRESS_SWITCH_1, _CMD_BS_7)
-    BS_11 = (_ADDRESS_SWITCH_1, _CMD_BS_11)
-    CLEAR = (_ADDRESS_SWITCH_1, _CMD_CLEAR)
-    POWER = (_ADDRESS_SWITCH_1, _CMD_POWER)
-    EJECT = (_ADDRESS_SWITCH_1, _CMD_EJECT)
-    STOP = (_ADDRESS_SWITCH_1, _CMD_STOP)
-    PAUSE = (_ADDRESS_SWITCH_1, _CMD_PAUSE)
-    PLAY = (_ADDRESS_SWITCH_1, _CMD_PLAY)
-    RECORD_START = (_ADDRESS_SWITCH_1, _CMD_RECORD_START)
-    RECORD_PAUSE = (_ADDRESS_SWITCH_1, _CMD_RECORD_PAUSE)
-    RECORD_STOP = (_ADDRESS_SWITCH_1, _CMD_RECORD_STOP)
-    DISPLAY = (_ADDRESS_SWITCH_1, _CMD_DISPLAY)
-    RECORDING_MODE = (_ADDRESS_SWITCH_1, _CMD_RECORDING_MODE)
-    MENU = (_ADDRESS_SWITCH_1, _CMD_MENU)
-    PROGRAM = (_ADDRESS_SWITCH_1, _CMD_PROGRAM)
-    TOP_MENU = (_ADDRESS_SWITCH_1, _CMD_TOP_MENU)
-    G_GUIDE2 = (_ADDRESS_SWITCH_1, _CMD_G_GUIDE2)
-    HOME = (_ADDRESS_SWITCH_1, _CMD_HOME)
-    RETURN = (_ADDRESS_SWITCH_1, _CMD_RETURN)
-    G_GUIDE = (_ADDRESS_SWITCH_1, _CMD_G_GUIDE)
-    SELECT = (_ADDRESS_SWITCH_1, _CMD_SELECT)
-    L3 = (_ADDRESS_SWITCH_1, _CMD_L3)
-    R3 = (_ADDRESS_SWITCH_1, _CMD_R3)
-    START = (_ADDRESS_SWITCH_1, _CMD_START)
-    UP = (_ADDRESS_SWITCH_1, _CMD_UP)
-    RIGHT = (_ADDRESS_SWITCH_1, _CMD_RIGHT)
-    DOWN = (_ADDRESS_SWITCH_1, _CMD_DOWN)
-    LEFT = (_ADDRESS_SWITCH_1, _CMD_LEFT)
-    L2_SCAN_BACK = (_ADDRESS_SWITCH_1, _CMD_L2_SCAN_BACK)
-    R2_SCAN_FORW = (_ADDRESS_SWITCH_1, _CMD_R2_SCAN_FORW)
-    L1_PREV = (_ADDRESS_SWITCH_1, _CMD_L1_PREV)
-    R1_NEXT = (_ADDRESS_SWITCH_1, _CMD_R1_NEXT)
-    TRIANGLE_OPTION = (_ADDRESS_SWITCH_1, _CMD_TRIANGLE_OPTION)
-    CIRCLE = (_ADDRESS_SWITCH_1, _CMD_CIRCLE)
-    CROSS_BACK = (_ADDRESS_SWITCH_1, _CMD_CROSS_BACK)
-    SQUARE_VIEW = (_ADDRESS_SWITCH_1, _CMD_SQUARE_VIEW)
-    ENTER = (_ADDRESS_SWITCH_1, _CMD_ENTER)
-    QUIT_GAME = (_ADDRESS_SWITCH_1, _CMD_QUIT_GAME)
-    DELETE = (_ADDRESS_SWITCH_1, _CMD_DELETE)
-    FLASH_FORW = (_ADDRESS_SWITCH_1, _CMD_FLASH_FORW)
-    FLASH_BACK = (_ADDRESS_SWITCH_1, _CMD_FLASH_BACK)
-
-
-class SonyPSXSwitch2Code(_PSXSwitchCodeMixin, Enum):
-    """Sony PSX (remote switch 2) IR command codes.
-
-    All codes use 20-bit SONY SIRC (address_bits=13).
-
-    address is 0x1A9B for switch position 2.
-
-    Values are (address, command) pairs.
-    """
-
-    NUM_1 = (_ADDRESS_SWITCH_2, _CMD_1)
-    NUM_2 = (_ADDRESS_SWITCH_2, _CMD_2)
-    NUM_3 = (_ADDRESS_SWITCH_2, _CMD_3)
-    NUM_4 = (_ADDRESS_SWITCH_2, _CMD_4)
-    NUM_5 = (_ADDRESS_SWITCH_2, _CMD_5)
-    NUM_6 = (_ADDRESS_SWITCH_2, _CMD_6)
-    NUM_7 = (_ADDRESS_SWITCH_2, _CMD_7)
-    NUM_8 = (_ADDRESS_SWITCH_2, _CMD_8)
-    NUM_9 = (_ADDRESS_SWITCH_2, _CMD_9)
-    NUM_10 = (_ADDRESS_SWITCH_2, _CMD_10)
-    NUM_11 = (_ADDRESS_SWITCH_2, _CMD_11)
-    NUM_12 = (_ADDRESS_SWITCH_2, _CMD_12)
-    BS_7 = (_ADDRESS_SWITCH_2, _CMD_BS_7)
-    BS_11 = (_ADDRESS_SWITCH_2, _CMD_BS_11)
-    CLEAR = (_ADDRESS_SWITCH_2, _CMD_CLEAR)
-    POWER = (_ADDRESS_SWITCH_2, _CMD_POWER)
-    EJECT = (_ADDRESS_SWITCH_2, _CMD_EJECT)
-    STOP = (_ADDRESS_SWITCH_2, _CMD_STOP)
-    PAUSE = (_ADDRESS_SWITCH_2, _CMD_PAUSE)
-    PLAY = (_ADDRESS_SWITCH_2, _CMD_PLAY)
-    RECORD_START = (_ADDRESS_SWITCH_2, _CMD_RECORD_START)
-    RECORD_PAUSE = (_ADDRESS_SWITCH_2, _CMD_RECORD_PAUSE)
-    RECORD_STOP = (_ADDRESS_SWITCH_2, _CMD_RECORD_STOP)
-    DISPLAY = (_ADDRESS_SWITCH_2, _CMD_DISPLAY)
-    RECORDING_MODE = (_ADDRESS_SWITCH_2, _CMD_RECORDING_MODE)
-    MENU = (_ADDRESS_SWITCH_2, _CMD_MENU)
-    PROGRAM = (_ADDRESS_SWITCH_2, _CMD_PROGRAM)
-    TOP_MENU = (_ADDRESS_SWITCH_2, _CMD_TOP_MENU)
-    G_GUIDE2 = (_ADDRESS_SWITCH_2, _CMD_G_GUIDE2)
-    HOME = (_ADDRESS_SWITCH_2, _CMD_HOME)
-    RETURN = (_ADDRESS_SWITCH_2, _CMD_RETURN)
-    G_GUIDE = (_ADDRESS_SWITCH_2, _CMD_G_GUIDE)
-    SELECT = (_ADDRESS_SWITCH_2, _CMD_SELECT)
-    L3 = (_ADDRESS_SWITCH_2, _CMD_L3)
-    R3 = (_ADDRESS_SWITCH_2, _CMD_R3)
-    START = (_ADDRESS_SWITCH_2, _CMD_START)
-    UP = (_ADDRESS_SWITCH_2, _CMD_UP)
-    RIGHT = (_ADDRESS_SWITCH_2, _CMD_RIGHT)
-    DOWN = (_ADDRESS_SWITCH_2, _CMD_DOWN)
-    LEFT = (_ADDRESS_SWITCH_2, _CMD_LEFT)
-    L2_SCAN_BACK = (_ADDRESS_SWITCH_2, _CMD_L2_SCAN_BACK)
-    R2_SCAN_FORW = (_ADDRESS_SWITCH_2, _CMD_R2_SCAN_FORW)
-    L1_PREV = (_ADDRESS_SWITCH_2, _CMD_L1_PREV)
-    R1_NEXT = (_ADDRESS_SWITCH_2, _CMD_R1_NEXT)
-    TRIANGLE_OPTION = (_ADDRESS_SWITCH_2, _CMD_TRIANGLE_OPTION)
-    CIRCLE = (_ADDRESS_SWITCH_2, _CMD_CIRCLE)
-    CROSS_BACK = (_ADDRESS_SWITCH_2, _CMD_CROSS_BACK)
-    SQUARE_VIEW = (_ADDRESS_SWITCH_2, _CMD_SQUARE_VIEW)
-    ENTER = (_ADDRESS_SWITCH_2, _CMD_ENTER)
-    QUIT_GAME = (_ADDRESS_SWITCH_2, _CMD_QUIT_GAME)
-    DELETE = (_ADDRESS_SWITCH_2, _CMD_DELETE)
-    FLASH_FORW = (_ADDRESS_SWITCH_2, _CMD_FLASH_FORW)
-    FLASH_BACK = (_ADDRESS_SWITCH_2, _CMD_FLASH_BACK)
-
-
-class SonyPSXSwitch3Code(_PSXSwitchCodeMixin, Enum):
-    """Sony PSX (remote switch 3) IR command codes.
-
-    All codes use 20-bit SONY SIRC (address_bits=13).
-
-    address is 0x1AA3 for switch position 3.
-
-    Values are (address, command) pairs.
-    """
-
-    NUM_1 = (_ADDRESS_SWITCH_3, _CMD_1)
-    NUM_2 = (_ADDRESS_SWITCH_3, _CMD_2)
-    NUM_3 = (_ADDRESS_SWITCH_3, _CMD_3)
-    NUM_4 = (_ADDRESS_SWITCH_3, _CMD_4)
-    NUM_5 = (_ADDRESS_SWITCH_3, _CMD_5)
-    NUM_6 = (_ADDRESS_SWITCH_3, _CMD_6)
-    NUM_7 = (_ADDRESS_SWITCH_3, _CMD_7)
-    NUM_8 = (_ADDRESS_SWITCH_3, _CMD_8)
-    NUM_9 = (_ADDRESS_SWITCH_3, _CMD_9)
-    NUM_10 = (_ADDRESS_SWITCH_3, _CMD_10)
-    NUM_11 = (_ADDRESS_SWITCH_3, _CMD_11)
-    NUM_12 = (_ADDRESS_SWITCH_3, _CMD_12)
-    BS_7 = (_ADDRESS_SWITCH_3, _CMD_BS_7)
-    BS_11 = (_ADDRESS_SWITCH_3, _CMD_BS_11)
-    CLEAR = (_ADDRESS_SWITCH_3, _CMD_CLEAR)
-    POWER = (_ADDRESS_SWITCH_3, _CMD_POWER)
-    EJECT = (_ADDRESS_SWITCH_3, _CMD_EJECT)
-    STOP = (_ADDRESS_SWITCH_3, _CMD_STOP)
-    PAUSE = (_ADDRESS_SWITCH_3, _CMD_PAUSE)
-    PLAY = (_ADDRESS_SWITCH_3, _CMD_PLAY)
-    RECORD_START = (_ADDRESS_SWITCH_3, _CMD_RECORD_START)
-    RECORD_PAUSE = (_ADDRESS_SWITCH_3, _CMD_RECORD_PAUSE)
-    RECORD_STOP = (_ADDRESS_SWITCH_3, _CMD_RECORD_STOP)
-    DISPLAY = (_ADDRESS_SWITCH_3, _CMD_DISPLAY)
-    RECORDING_MODE = (_ADDRESS_SWITCH_3, _CMD_RECORDING_MODE)
-    MENU = (_ADDRESS_SWITCH_3, _CMD_MENU)
-    PROGRAM = (_ADDRESS_SWITCH_3, _CMD_PROGRAM)
-    TOP_MENU = (_ADDRESS_SWITCH_3, _CMD_TOP_MENU)
-    G_GUIDE2 = (_ADDRESS_SWITCH_3, _CMD_G_GUIDE2)
-    HOME = (_ADDRESS_SWITCH_3, _CMD_HOME)
-    RETURN = (_ADDRESS_SWITCH_3, _CMD_RETURN)
-    G_GUIDE = (_ADDRESS_SWITCH_3, _CMD_G_GUIDE)
-    SELECT = (_ADDRESS_SWITCH_3, _CMD_SELECT)
-    L3 = (_ADDRESS_SWITCH_3, _CMD_L3)
-    R3 = (_ADDRESS_SWITCH_3, _CMD_R3)
-    START = (_ADDRESS_SWITCH_3, _CMD_START)
-    UP = (_ADDRESS_SWITCH_3, _CMD_UP)
-    RIGHT = (_ADDRESS_SWITCH_3, _CMD_RIGHT)
-    DOWN = (_ADDRESS_SWITCH_3, _CMD_DOWN)
-    LEFT = (_ADDRESS_SWITCH_3, _CMD_LEFT)
-    L2_SCAN_BACK = (_ADDRESS_SWITCH_3, _CMD_L2_SCAN_BACK)
-    R2_SCAN_FORW = (_ADDRESS_SWITCH_3, _CMD_R2_SCAN_FORW)
-    L1_PREV = (_ADDRESS_SWITCH_3, _CMD_L1_PREV)
-    R1_NEXT = (_ADDRESS_SWITCH_3, _CMD_R1_NEXT)
-    TRIANGLE_OPTION = (_ADDRESS_SWITCH_3, _CMD_TRIANGLE_OPTION)
-    CIRCLE = (_ADDRESS_SWITCH_3, _CMD_CIRCLE)
-    CROSS_BACK = (_ADDRESS_SWITCH_3, _CMD_CROSS_BACK)
-    SQUARE_VIEW = (_ADDRESS_SWITCH_3, _CMD_SQUARE_VIEW)
-    ENTER = (_ADDRESS_SWITCH_3, _CMD_ENTER)
-    QUIT_GAME = (_ADDRESS_SWITCH_3, _CMD_QUIT_GAME)
-    DELETE = (_ADDRESS_SWITCH_3, _CMD_DELETE)
-    FLASH_FORW = (_ADDRESS_SWITCH_3, _CMD_FLASH_FORW)
-    FLASH_BACK = (_ADDRESS_SWITCH_3, _CMD_FLASH_BACK)
 
 
 @dataclass(frozen=True, slots=True)
@@ -318,72 +119,36 @@ class PSXModel:
     codes: frozenset[Enum]
 
 
+# Code grouping by remote model
+_P001_ONLY_COMMANDS = frozenset(
+    [
+        SonyPSXCode.BS_7,
+        SonyPSXCode.BS_11,
+        SonyPSXCode.G_GUIDE,
+    ]
+)
+
+_P002J_ONLY_COMMANDS = frozenset(
+    [
+        SonyPSXCode.G_GUIDE2,
+        SonyPSXCode.FLASH_FORW,
+        SonyPSXCode.FLASH_BACK,
+    ]
+)
+
 # Model variants: earlier (RMT-P001) and later (RMT-P002J) PSX models.
-# Each grouped by switch position.
 # Earlier models include only common codes and P001-exclusive codes.
 # Later models include common codes and P002J-exclusive codes.
-PSX_EARLIER_MODELS_SWITCH_1 = PSXModel(
+PSX_EARLIER_MODELS = PSXModel(
     name=(
-        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100), switch 1"
+        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100)"
     ),
-    codes=frozenset(
-        code
-        for code in SonyPSXSwitch1Code
-        if code.value[1] not in (_P002J_ONLY_COMMANDS)
-    ),
+    codes=frozenset(code for code in SonyPSXCode if code not in _P002J_ONLY_COMMANDS),
 )
 
-PSX_EARLIER_MODELS_SWITCH_2 = PSXModel(
+PSX_LATER_MODELS = PSXModel(
     name=(
-        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100), switch 2"
+        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700)"
     ),
-    codes=frozenset(
-        code
-        for code in SonyPSXSwitch2Code
-        if code.value[1] not in (_P002J_ONLY_COMMANDS)
-    ),
-)
-
-PSX_EARLIER_MODELS_SWITCH_3 = PSXModel(
-    name=(
-        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100), switch 3"
-    ),
-    codes=frozenset(
-        code
-        for code in SonyPSXSwitch3Code
-        if code.value[1] not in (_P002J_ONLY_COMMANDS)
-    ),
-)
-
-PSX_LATER_MODELS_SWITCH_1 = PSXModel(
-    name=(
-        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700), switch 1"
-    ),
-    codes=frozenset(
-        code
-        for code in SonyPSXSwitch1Code
-        if code.value[1] not in (_P001_ONLY_COMMANDS)
-    ),
-)
-
-PSX_LATER_MODELS_SWITCH_2 = PSXModel(
-    name=(
-        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700), switch 2"
-    ),
-    codes=frozenset(
-        code
-        for code in SonyPSXSwitch2Code
-        if code.value[1] not in (_P001_ONLY_COMMANDS)
-    ),
-)
-
-PSX_LATER_MODELS_SWITCH_3 = PSXModel(
-    name=(
-        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700), switch 3"
-    ),
-    codes=frozenset(
-        code
-        for code in SonyPSXSwitch3Code
-        if code.value[1] not in (_P001_ONLY_COMMANDS)
-    ),
+    codes=frozenset(code for code in SonyPSXCode if code not in _P001_ONLY_COMMANDS),
 )

--- a/infrared_protocols/codes/sony/psx.py
+++ b/infrared_protocols/codes/sony/psx.py
@@ -1,0 +1,389 @@
+"""Command codes for Sony PSX (DESR-XXXX).
+
+Based on the following remote control models:
+- RMT-P001 (bundled with earlier PSX models)
+- RMT-P002J (bundled with later PSX models)
+
+Supported PSX models:
+- DESR-5000, DESR-7000, DESR-5100, DESR-7100 (earlier models)
+- DESR-5500, DESR-7500, DESR-5700, DESR-7700 (later models)
+
+The PSX remote receiver unit has a switch that selects the IR address.
+Three switch positions (1, 2, 3) map to three distinct addresses, allowing
+multiple PSX units to be controlled independently in the same room.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from ...commands import Command
+from ...commands.sony import SonyCommand
+
+_ADDRESS_SWITCH_1 = 0x1A93
+_ADDRESS_SWITCH_2 = 0x1A9B
+_ADDRESS_SWITCH_3 = 0x1AA3
+
+# region Command code values
+_CMD_1 = 0
+_CMD_2 = 1
+_CMD_3 = 2
+_CMD_4 = 3
+_CMD_5 = 4
+_CMD_6 = 5
+_CMD_7 = 6
+_CMD_8 = 7
+_CMD_9 = 8
+_CMD_10 = 9
+_CMD_11 = 10
+_CMD_12 = 11
+_CMD_BS_7 = 13  # RMT-P001 only
+_CMD_BS_11 = 14  # RMT-P001 only
+_CMD_CLEAR = 15
+_CMD_POWER = 21
+_CMD_EJECT = 22
+_CMD_STOP = 24
+_CMD_PAUSE = 25
+_CMD_PLAY = 26
+_CMD_RECORD_START = 29
+_CMD_RECORD_PAUSE = 30
+_CMD_RECORD_STOP = 31
+_CMD_DISPLAY = 37
+_CMD_RECORDING_MODE = 38
+_CMD_MENU = 41
+_CMD_PROGRAM = 42
+_CMD_TOP_MENU = 44
+_CMD_G_GUIDE2 = 65  # RMT-P002J only
+_CMD_HOME = 66
+_CMD_RETURN = 67
+_CMD_G_GUIDE = 69  # RMT-P001 only
+_CMD_SELECT = 80
+_CMD_L3 = 81
+_CMD_R3 = 82
+_CMD_START = 83
+_CMD_UP = 84
+_CMD_RIGHT = 85
+_CMD_DOWN = 86
+_CMD_LEFT = 87
+_CMD_L2_SCAN_BACK = 88
+_CMD_R2_SCAN_FORW = 89
+_CMD_L1_PREV = 90
+_CMD_R1_NEXT = 91
+_CMD_TRIANGLE_OPTION = 92
+_CMD_CIRCLE = 93
+_CMD_CROSS_BACK = 94
+_CMD_SQUARE_VIEW = 95
+_CMD_ENTER = 96
+_CMD_QUIT_GAME = 97
+_CMD_DELETE = 98
+_CMD_FLASH_FORW = 117  # RMT-P002J only
+_CMD_FLASH_BACK = 118  # RMT-P002J only
+# endregion Command code values
+
+# Code grouping by remote model
+_P001_ONLY_COMMANDS = frozenset(
+    [
+        _CMD_G_GUIDE,
+        _CMD_BS_7,
+        _CMD_BS_11,
+    ]
+)
+
+_P002J_ONLY_COMMANDS = frozenset(
+    [
+        _CMD_G_GUIDE2,
+        _CMD_FLASH_FORW,
+        _CMD_FLASH_BACK,
+    ]
+)
+
+
+class _PSXSwitchCodeMixin:
+    """Non-Enum mixin providing to_command() for PSX DIP-switch code enums.
+
+    Values in the concrete Enum subclasses are (address, command) pairs.
+    """
+
+    def to_command(self) -> Command:
+        """Build a SONY SIRC command for this PSX code."""
+        address, command = self.value  # type: ignore[attr-defined]
+        return SonyCommand(
+            address=address,
+            address_bits=13,
+            command=command,
+        )
+
+
+class SonyPSXSwitch1Code(_PSXSwitchCodeMixin, Enum):
+    """Sony PSX (remote switch 1) IR command codes.
+
+    All codes use 20-bit SONY SIRC (address_bits=13).
+
+    address is 0x1A93 for switch position 1.
+
+    Values are (address, command) pairs.
+    """
+
+    NUM_1 = (_ADDRESS_SWITCH_1, _CMD_1)
+    NUM_2 = (_ADDRESS_SWITCH_1, _CMD_2)
+    NUM_3 = (_ADDRESS_SWITCH_1, _CMD_3)
+    NUM_4 = (_ADDRESS_SWITCH_1, _CMD_4)
+    NUM_5 = (_ADDRESS_SWITCH_1, _CMD_5)
+    NUM_6 = (_ADDRESS_SWITCH_1, _CMD_6)
+    NUM_7 = (_ADDRESS_SWITCH_1, _CMD_7)
+    NUM_8 = (_ADDRESS_SWITCH_1, _CMD_8)
+    NUM_9 = (_ADDRESS_SWITCH_1, _CMD_9)
+    NUM_10 = (_ADDRESS_SWITCH_1, _CMD_10)
+    NUM_11 = (_ADDRESS_SWITCH_1, _CMD_11)
+    NUM_12 = (_ADDRESS_SWITCH_1, _CMD_12)
+    BS_7 = (_ADDRESS_SWITCH_1, _CMD_BS_7)
+    BS_11 = (_ADDRESS_SWITCH_1, _CMD_BS_11)
+    CLEAR = (_ADDRESS_SWITCH_1, _CMD_CLEAR)
+    POWER = (_ADDRESS_SWITCH_1, _CMD_POWER)
+    EJECT = (_ADDRESS_SWITCH_1, _CMD_EJECT)
+    STOP = (_ADDRESS_SWITCH_1, _CMD_STOP)
+    PAUSE = (_ADDRESS_SWITCH_1, _CMD_PAUSE)
+    PLAY = (_ADDRESS_SWITCH_1, _CMD_PLAY)
+    RECORD_START = (_ADDRESS_SWITCH_1, _CMD_RECORD_START)
+    RECORD_PAUSE = (_ADDRESS_SWITCH_1, _CMD_RECORD_PAUSE)
+    RECORD_STOP = (_ADDRESS_SWITCH_1, _CMD_RECORD_STOP)
+    DISPLAY = (_ADDRESS_SWITCH_1, _CMD_DISPLAY)
+    RECORDING_MODE = (_ADDRESS_SWITCH_1, _CMD_RECORDING_MODE)
+    MENU = (_ADDRESS_SWITCH_1, _CMD_MENU)
+    PROGRAM = (_ADDRESS_SWITCH_1, _CMD_PROGRAM)
+    TOP_MENU = (_ADDRESS_SWITCH_1, _CMD_TOP_MENU)
+    G_GUIDE2 = (_ADDRESS_SWITCH_1, _CMD_G_GUIDE2)
+    HOME = (_ADDRESS_SWITCH_1, _CMD_HOME)
+    RETURN = (_ADDRESS_SWITCH_1, _CMD_RETURN)
+    G_GUIDE = (_ADDRESS_SWITCH_1, _CMD_G_GUIDE)
+    SELECT = (_ADDRESS_SWITCH_1, _CMD_SELECT)
+    L3 = (_ADDRESS_SWITCH_1, _CMD_L3)
+    R3 = (_ADDRESS_SWITCH_1, _CMD_R3)
+    START = (_ADDRESS_SWITCH_1, _CMD_START)
+    UP = (_ADDRESS_SWITCH_1, _CMD_UP)
+    RIGHT = (_ADDRESS_SWITCH_1, _CMD_RIGHT)
+    DOWN = (_ADDRESS_SWITCH_1, _CMD_DOWN)
+    LEFT = (_ADDRESS_SWITCH_1, _CMD_LEFT)
+    L2_SCAN_BACK = (_ADDRESS_SWITCH_1, _CMD_L2_SCAN_BACK)
+    R2_SCAN_FORW = (_ADDRESS_SWITCH_1, _CMD_R2_SCAN_FORW)
+    L1_PREV = (_ADDRESS_SWITCH_1, _CMD_L1_PREV)
+    R1_NEXT = (_ADDRESS_SWITCH_1, _CMD_R1_NEXT)
+    TRIANGLE_OPTION = (_ADDRESS_SWITCH_1, _CMD_TRIANGLE_OPTION)
+    CIRCLE = (_ADDRESS_SWITCH_1, _CMD_CIRCLE)
+    CROSS_BACK = (_ADDRESS_SWITCH_1, _CMD_CROSS_BACK)
+    SQUARE_VIEW = (_ADDRESS_SWITCH_1, _CMD_SQUARE_VIEW)
+    ENTER = (_ADDRESS_SWITCH_1, _CMD_ENTER)
+    QUIT_GAME = (_ADDRESS_SWITCH_1, _CMD_QUIT_GAME)
+    DELETE = (_ADDRESS_SWITCH_1, _CMD_DELETE)
+    FLASH_FORW = (_ADDRESS_SWITCH_1, _CMD_FLASH_FORW)
+    FLASH_BACK = (_ADDRESS_SWITCH_1, _CMD_FLASH_BACK)
+
+
+class SonyPSXSwitch2Code(_PSXSwitchCodeMixin, Enum):
+    """Sony PSX (remote switch 2) IR command codes.
+
+    All codes use 20-bit SONY SIRC (address_bits=13).
+
+    address is 0x1A9B for switch position 2.
+
+    Values are (address, command) pairs.
+    """
+
+    NUM_1 = (_ADDRESS_SWITCH_2, _CMD_1)
+    NUM_2 = (_ADDRESS_SWITCH_2, _CMD_2)
+    NUM_3 = (_ADDRESS_SWITCH_2, _CMD_3)
+    NUM_4 = (_ADDRESS_SWITCH_2, _CMD_4)
+    NUM_5 = (_ADDRESS_SWITCH_2, _CMD_5)
+    NUM_6 = (_ADDRESS_SWITCH_2, _CMD_6)
+    NUM_7 = (_ADDRESS_SWITCH_2, _CMD_7)
+    NUM_8 = (_ADDRESS_SWITCH_2, _CMD_8)
+    NUM_9 = (_ADDRESS_SWITCH_2, _CMD_9)
+    NUM_10 = (_ADDRESS_SWITCH_2, _CMD_10)
+    NUM_11 = (_ADDRESS_SWITCH_2, _CMD_11)
+    NUM_12 = (_ADDRESS_SWITCH_2, _CMD_12)
+    BS_7 = (_ADDRESS_SWITCH_2, _CMD_BS_7)
+    BS_11 = (_ADDRESS_SWITCH_2, _CMD_BS_11)
+    CLEAR = (_ADDRESS_SWITCH_2, _CMD_CLEAR)
+    POWER = (_ADDRESS_SWITCH_2, _CMD_POWER)
+    EJECT = (_ADDRESS_SWITCH_2, _CMD_EJECT)
+    STOP = (_ADDRESS_SWITCH_2, _CMD_STOP)
+    PAUSE = (_ADDRESS_SWITCH_2, _CMD_PAUSE)
+    PLAY = (_ADDRESS_SWITCH_2, _CMD_PLAY)
+    RECORD_START = (_ADDRESS_SWITCH_2, _CMD_RECORD_START)
+    RECORD_PAUSE = (_ADDRESS_SWITCH_2, _CMD_RECORD_PAUSE)
+    RECORD_STOP = (_ADDRESS_SWITCH_2, _CMD_RECORD_STOP)
+    DISPLAY = (_ADDRESS_SWITCH_2, _CMD_DISPLAY)
+    RECORDING_MODE = (_ADDRESS_SWITCH_2, _CMD_RECORDING_MODE)
+    MENU = (_ADDRESS_SWITCH_2, _CMD_MENU)
+    PROGRAM = (_ADDRESS_SWITCH_2, _CMD_PROGRAM)
+    TOP_MENU = (_ADDRESS_SWITCH_2, _CMD_TOP_MENU)
+    G_GUIDE2 = (_ADDRESS_SWITCH_2, _CMD_G_GUIDE2)
+    HOME = (_ADDRESS_SWITCH_2, _CMD_HOME)
+    RETURN = (_ADDRESS_SWITCH_2, _CMD_RETURN)
+    G_GUIDE = (_ADDRESS_SWITCH_2, _CMD_G_GUIDE)
+    SELECT = (_ADDRESS_SWITCH_2, _CMD_SELECT)
+    L3 = (_ADDRESS_SWITCH_2, _CMD_L3)
+    R3 = (_ADDRESS_SWITCH_2, _CMD_R3)
+    START = (_ADDRESS_SWITCH_2, _CMD_START)
+    UP = (_ADDRESS_SWITCH_2, _CMD_UP)
+    RIGHT = (_ADDRESS_SWITCH_2, _CMD_RIGHT)
+    DOWN = (_ADDRESS_SWITCH_2, _CMD_DOWN)
+    LEFT = (_ADDRESS_SWITCH_2, _CMD_LEFT)
+    L2_SCAN_BACK = (_ADDRESS_SWITCH_2, _CMD_L2_SCAN_BACK)
+    R2_SCAN_FORW = (_ADDRESS_SWITCH_2, _CMD_R2_SCAN_FORW)
+    L1_PREV = (_ADDRESS_SWITCH_2, _CMD_L1_PREV)
+    R1_NEXT = (_ADDRESS_SWITCH_2, _CMD_R1_NEXT)
+    TRIANGLE_OPTION = (_ADDRESS_SWITCH_2, _CMD_TRIANGLE_OPTION)
+    CIRCLE = (_ADDRESS_SWITCH_2, _CMD_CIRCLE)
+    CROSS_BACK = (_ADDRESS_SWITCH_2, _CMD_CROSS_BACK)
+    SQUARE_VIEW = (_ADDRESS_SWITCH_2, _CMD_SQUARE_VIEW)
+    ENTER = (_ADDRESS_SWITCH_2, _CMD_ENTER)
+    QUIT_GAME = (_ADDRESS_SWITCH_2, _CMD_QUIT_GAME)
+    DELETE = (_ADDRESS_SWITCH_2, _CMD_DELETE)
+    FLASH_FORW = (_ADDRESS_SWITCH_2, _CMD_FLASH_FORW)
+    FLASH_BACK = (_ADDRESS_SWITCH_2, _CMD_FLASH_BACK)
+
+
+class SonyPSXSwitch3Code(_PSXSwitchCodeMixin, Enum):
+    """Sony PSX (remote switch 3) IR command codes.
+
+    All codes use 20-bit SONY SIRC (address_bits=13).
+
+    address is 0x1AA3 for switch position 3.
+
+    Values are (address, command) pairs.
+    """
+
+    NUM_1 = (_ADDRESS_SWITCH_3, _CMD_1)
+    NUM_2 = (_ADDRESS_SWITCH_3, _CMD_2)
+    NUM_3 = (_ADDRESS_SWITCH_3, _CMD_3)
+    NUM_4 = (_ADDRESS_SWITCH_3, _CMD_4)
+    NUM_5 = (_ADDRESS_SWITCH_3, _CMD_5)
+    NUM_6 = (_ADDRESS_SWITCH_3, _CMD_6)
+    NUM_7 = (_ADDRESS_SWITCH_3, _CMD_7)
+    NUM_8 = (_ADDRESS_SWITCH_3, _CMD_8)
+    NUM_9 = (_ADDRESS_SWITCH_3, _CMD_9)
+    NUM_10 = (_ADDRESS_SWITCH_3, _CMD_10)
+    NUM_11 = (_ADDRESS_SWITCH_3, _CMD_11)
+    NUM_12 = (_ADDRESS_SWITCH_3, _CMD_12)
+    BS_7 = (_ADDRESS_SWITCH_3, _CMD_BS_7)
+    BS_11 = (_ADDRESS_SWITCH_3, _CMD_BS_11)
+    CLEAR = (_ADDRESS_SWITCH_3, _CMD_CLEAR)
+    POWER = (_ADDRESS_SWITCH_3, _CMD_POWER)
+    EJECT = (_ADDRESS_SWITCH_3, _CMD_EJECT)
+    STOP = (_ADDRESS_SWITCH_3, _CMD_STOP)
+    PAUSE = (_ADDRESS_SWITCH_3, _CMD_PAUSE)
+    PLAY = (_ADDRESS_SWITCH_3, _CMD_PLAY)
+    RECORD_START = (_ADDRESS_SWITCH_3, _CMD_RECORD_START)
+    RECORD_PAUSE = (_ADDRESS_SWITCH_3, _CMD_RECORD_PAUSE)
+    RECORD_STOP = (_ADDRESS_SWITCH_3, _CMD_RECORD_STOP)
+    DISPLAY = (_ADDRESS_SWITCH_3, _CMD_DISPLAY)
+    RECORDING_MODE = (_ADDRESS_SWITCH_3, _CMD_RECORDING_MODE)
+    MENU = (_ADDRESS_SWITCH_3, _CMD_MENU)
+    PROGRAM = (_ADDRESS_SWITCH_3, _CMD_PROGRAM)
+    TOP_MENU = (_ADDRESS_SWITCH_3, _CMD_TOP_MENU)
+    G_GUIDE2 = (_ADDRESS_SWITCH_3, _CMD_G_GUIDE2)
+    HOME = (_ADDRESS_SWITCH_3, _CMD_HOME)
+    RETURN = (_ADDRESS_SWITCH_3, _CMD_RETURN)
+    G_GUIDE = (_ADDRESS_SWITCH_3, _CMD_G_GUIDE)
+    SELECT = (_ADDRESS_SWITCH_3, _CMD_SELECT)
+    L3 = (_ADDRESS_SWITCH_3, _CMD_L3)
+    R3 = (_ADDRESS_SWITCH_3, _CMD_R3)
+    START = (_ADDRESS_SWITCH_3, _CMD_START)
+    UP = (_ADDRESS_SWITCH_3, _CMD_UP)
+    RIGHT = (_ADDRESS_SWITCH_3, _CMD_RIGHT)
+    DOWN = (_ADDRESS_SWITCH_3, _CMD_DOWN)
+    LEFT = (_ADDRESS_SWITCH_3, _CMD_LEFT)
+    L2_SCAN_BACK = (_ADDRESS_SWITCH_3, _CMD_L2_SCAN_BACK)
+    R2_SCAN_FORW = (_ADDRESS_SWITCH_3, _CMD_R2_SCAN_FORW)
+    L1_PREV = (_ADDRESS_SWITCH_3, _CMD_L1_PREV)
+    R1_NEXT = (_ADDRESS_SWITCH_3, _CMD_R1_NEXT)
+    TRIANGLE_OPTION = (_ADDRESS_SWITCH_3, _CMD_TRIANGLE_OPTION)
+    CIRCLE = (_ADDRESS_SWITCH_3, _CMD_CIRCLE)
+    CROSS_BACK = (_ADDRESS_SWITCH_3, _CMD_CROSS_BACK)
+    SQUARE_VIEW = (_ADDRESS_SWITCH_3, _CMD_SQUARE_VIEW)
+    ENTER = (_ADDRESS_SWITCH_3, _CMD_ENTER)
+    QUIT_GAME = (_ADDRESS_SWITCH_3, _CMD_QUIT_GAME)
+    DELETE = (_ADDRESS_SWITCH_3, _CMD_DELETE)
+    FLASH_FORW = (_ADDRESS_SWITCH_3, _CMD_FLASH_FORW)
+    FLASH_BACK = (_ADDRESS_SWITCH_3, _CMD_FLASH_BACK)
+
+
+@dataclass(frozen=True, slots=True)
+class PSXModel:
+    """A Sony PSX model and the IR codes it accepts for a specific switch setting."""
+
+    name: str
+    codes: frozenset[Enum]
+
+
+# Model variants: earlier (RMT-P001) and later (RMT-P002J) PSX models.
+# Each grouped by switch position.
+# Earlier models include only common codes and P001-exclusive codes.
+# Later models include common codes and P002J-exclusive codes.
+PSX_EARLIER_MODELS_SWITCH_1 = PSXModel(
+    name=(
+        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100), switch 1"
+    ),
+    codes=frozenset(
+        code
+        for code in SonyPSXSwitch1Code
+        if code.value[1] not in (_P002J_ONLY_COMMANDS)
+    ),
+)
+
+PSX_EARLIER_MODELS_SWITCH_2 = PSXModel(
+    name=(
+        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100), switch 2"
+    ),
+    codes=frozenset(
+        code
+        for code in SonyPSXSwitch2Code
+        if code.value[1] not in (_P002J_ONLY_COMMANDS)
+    ),
+)
+
+PSX_EARLIER_MODELS_SWITCH_3 = PSXModel(
+    name=(
+        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100), switch 3"
+    ),
+    codes=frozenset(
+        code
+        for code in SonyPSXSwitch3Code
+        if code.value[1] not in (_P002J_ONLY_COMMANDS)
+    ),
+)
+
+PSX_LATER_MODELS_SWITCH_1 = PSXModel(
+    name=(
+        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700), switch 1"
+    ),
+    codes=frozenset(
+        code
+        for code in SonyPSXSwitch1Code
+        if code.value[1] not in (_P001_ONLY_COMMANDS)
+    ),
+)
+
+PSX_LATER_MODELS_SWITCH_2 = PSXModel(
+    name=(
+        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700), switch 2"
+    ),
+    codes=frozenset(
+        code
+        for code in SonyPSXSwitch2Code
+        if code.value[1] not in (_P001_ONLY_COMMANDS)
+    ),
+)
+
+PSX_LATER_MODELS_SWITCH_3 = PSXModel(
+    name=(
+        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700), switch 3"
+    ),
+    codes=frozenset(
+        code
+        for code in SonyPSXSwitch3Code
+        if code.value[1] not in (_P001_ONLY_COMMANDS)
+    ),
+)

--- a/infrared_protocols/codes/sony/psx.py
+++ b/infrared_protocols/codes/sony/psx.py
@@ -140,15 +140,11 @@ _P002J_ONLY_COMMANDS = frozenset(
 # Earlier models include only common codes and P001-exclusive codes.
 # Later models include common codes and P002J-exclusive codes.
 PSX_EARLIER_MODELS = PSXModel(
-    name=(
-        "PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100)"
-    ),
+    name=("PSX earlier models (DESR-5000, DESR-7000, DESR-5100, and DESR-7100)"),
     codes=frozenset(code for code in SonyPSXCode if code not in _P002J_ONLY_COMMANDS),
 )
 
 PSX_LATER_MODELS = PSXModel(
-    name=(
-        "PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700)"
-    ),
+    name=("PSX later models (DESR-5500, DESR-7500, DESR-5700, and DESR-7700)"),
     codes=frozenset(code for code in SonyPSXCode if code not in _P001_ONLY_COMMANDS),
 )

--- a/infrared_protocols/codes/sony/psx.py
+++ b/infrared_protocols/codes/sony/psx.py
@@ -100,7 +100,7 @@ class SonyPSXCode(Enum):
             Each position maps to a distinct IR address, allowing multiple PSX units
             to be controlled independently in the same room. Defaults to 1.
         """
-        if switch not in _SWITCH_TO_ADDRESS.keys():
+        if switch not in _SWITCH_TO_ADDRESS:
             raise ValueError(f"Invalid switch position: {switch}")
 
         command = self.value
@@ -116,7 +116,7 @@ class PSXModel:
     """A Sony PSX model and the IR codes it accepts for a specific switch setting."""
 
     name: str
-    codes: frozenset[Enum]
+    codes: frozenset[SonyPSXCode]
 
 
 # Code grouping by remote model

--- a/infrared_protocols/commands/sony.py
+++ b/infrared_protocols/commands/sony.py
@@ -5,7 +5,7 @@ from typing import override
 from . import Command
 
 
-class SONYCommand(Command):
+class SonyCommand(Command):
     """SONY SIRC IR command."""
 
     address: int

--- a/infrared_protocols/commands/sony.py
+++ b/infrared_protocols/commands/sony.py
@@ -19,7 +19,6 @@ class SonyCommand(Command):
         address_bits: int,
         command: int,
         modulation: int = 40000,
-        repeat_count: int = 0,
     ) -> None:
         """Initialize the SONY SIRC IR command."""
         if address_bits not in (5, 8, 13):
@@ -28,7 +27,7 @@ class SonyCommand(Command):
             raise ValueError("SONY SIRC address is out of range for address_bits")
         if not 0 <= command <= 0x7F:
             raise ValueError("SONY SIRC command must be in range 0x00..0x7F")
-        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        super().__init__(modulation=modulation)
         self.address = address
         self.address_bits = address_bits
         self.command = command
@@ -69,11 +68,4 @@ class SonyCommand(Command):
         trailer_low = frame_period - sum(abs(timing) for timing in frame)
         frame.append(-trailer_low)
 
-        timings = list(frame)
-
-        # SONY SIRC repeats by retransmitting the same full frame.
-        if self.repeat_count > 0:
-            for _ in range(self.repeat_count):
-                timings.extend(frame)
-
-        return timings
+        return frame

--- a/infrared_protocols/commands/sony.py
+++ b/infrared_protocols/commands/sony.py
@@ -1,0 +1,79 @@
+"""SONY SIRC IR command."""
+
+from typing import override
+
+from . import Command
+
+
+class SONYCommand(Command):
+    """SONY SIRC IR command."""
+
+    address: int
+    address_bits: int
+    command: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        address_bits: int,
+        command: int,
+        modulation: int = 40000,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the SONY SIRC IR command."""
+        if address_bits not in (5, 8, 13):
+            raise ValueError("SONY SIRC address_bits must be one of 5, 8, or 13")
+        if not 0 <= address < (1 << address_bits):
+            raise ValueError("SONY SIRC address is out of range for address_bits")
+        if not 0 <= command <= 0x7F:
+            raise ValueError("SONY SIRC command must be in range 0x00..0x7F")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.address_bits = address_bits
+        self.command = command
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the SONY SIRC command.
+
+        SONY SIRC protocol timing:
+        - T (timing unit): 600µs
+        - Leader pulse: 4T high
+        - Logical '0': 1T low, 1T high
+        - Logical '1': 1T low, 2T high
+        - Trailer: (75 - leader and data length)T low (total: 45ms)
+        - No repeat code; instead, it resends the same frame
+
+        Data format (12/15/20 bits, LSB first):
+        - command (7-bit) + address (5/8/13-bit)
+        """
+        t = 600
+        leader_high = 4 * t
+        zero_high = 1 * t
+        one_high = 2 * t
+        bit_low = 1 * t
+        frame_period = 45000
+
+        total_bits = 7 + self.address_bits
+        data = self.command | (self.address << 7)
+
+        frame: list[int] = [leader_high]
+
+        for _ in range(total_bits):
+            bit = data & 1
+            frame.append(-bit_low)
+            frame.append(one_high if bit else zero_high)
+            data >>= 1
+
+        trailer_low = frame_period - sum(abs(timing) for timing in frame)
+        frame.append(-trailer_low)
+
+        timings = list(frame)
+
+        # SONY SIRC repeats by retransmitting the same full frame.
+        if self.repeat_count > 0:
+            for _ in range(self.repeat_count):
+                timings.extend(frame)
+
+        return timings

--- a/tests/commands/test_sony.py
+++ b/tests/commands/test_sony.py
@@ -1,0 +1,100 @@
+"""Tests for the SONY SIRC IR command encoder."""
+
+import pytest
+
+from infrared_protocols.commands.sony import SONYCommand
+
+
+def test_sony_command_get_raw_timings_12_bit_standard() -> None:
+    """Test SONY SIRC 12-bit timings for a 7-bit command + 5-bit address."""
+    # command=0x15 -> bits (LSB first): 1,0,1,0,1,0,0
+    # address=0x01 -> bits (LSB first): 1,0,0,0,0
+    expected_raw_timings = [
+        2400,
+        -600,
+        1200,
+        -600,
+        600,
+        -600,
+        1200,
+        -600,
+        600,
+        -600,
+        1200,
+        -600,
+        600,
+        -600,
+        600,
+        -600,
+        1200,
+        -600,
+        600,
+        -600,
+        600,
+        -600,
+        600,
+        -600,
+        600,
+        -25800,
+    ]
+    command = SONYCommand(address=0x01, address_bits=5, command=0x15, repeat_count=0)
+    timings = command.get_raw_timings()
+    assert timings == expected_raw_timings
+    assert command.modulation == 40000
+
+    # Trailer low = 45000 - (2400 + (4*1800) + (8*1200)) = 25800
+    command_with_repeats = SONYCommand(
+        address=command.address,
+        address_bits=command.address_bits,
+        command=command.command,
+        repeat_count=2,
+    )
+    timings_with_repeats = command_with_repeats.get_raw_timings()
+    assert timings_with_repeats == [
+        *expected_raw_timings,
+        *expected_raw_timings,
+        *expected_raw_timings,
+    ]
+
+
+def test_sony_command_get_raw_timings_15_bit() -> None:
+    """Test SONY SIRC 15-bit framing for an 8-bit address."""
+    command = SONYCommand(address=0xA8, address_bits=8, command=0x02, repeat_count=0)
+    timings = command.get_raw_timings()
+
+    # 15-bit frame: leader high + 15 low/high pairs + trailer low
+    assert len(timings) == 2 + (15 * 2)
+    assert timings[0] == 2400
+    assert timings[-1] == -22200
+
+
+def test_sony_command_get_raw_timings_20_bit() -> None:
+    """Test SONY SIRC 20-bit framing for a 13-bit address."""
+    command = SONYCommand(address=0x1ABC, address_bits=13, command=0x34, repeat_count=0)
+    timings = command.get_raw_timings()
+
+    # 20-bit frame: leader high + 20 low/high pairs + trailer low
+    assert len(timings) == 2 + (20 * 2)
+    assert timings[0] == 2400
+    assert timings[-1] == -12000
+
+
+@pytest.mark.parametrize(
+    ("address", "address_bits", "command"),
+    [
+        (-1, 5, 0x00),
+        (0x20, 5, 0x00),
+        (0x100, 8, 0x00),
+        (0x2000, 13, 0x00),
+        (0x00, 4, 0x00),
+        (0x00, 6, 0x00),
+        (0x00, 5, -1),
+        (0x00, 5, 0x80),
+    ],
+)
+def test_sony_command_rejects_out_of_range(
+    address: int, address_bits: int, command: int
+) -> None:
+    """SONY SIRC fields must fit address<=13 bits and command<=7 bits."""
+    with pytest.raises(ValueError):
+        SONYCommand(address=address, address_bits=address_bits, command=command)

--- a/tests/commands/test_sony.py
+++ b/tests/commands/test_sony.py
@@ -37,29 +37,15 @@ def test_sony_command_get_raw_timings_12_bit_standard() -> None:
         600,
         -25800,
     ]
-    command = SonyCommand(address=0x01, address_bits=5, command=0x15, repeat_count=0)
+    command = SonyCommand(address=0x01, address_bits=5, command=0x15)
     timings = command.get_raw_timings()
     assert timings == expected_raw_timings
     assert command.modulation == 40000
 
-    # Trailer low = 45000 - (2400 + (4*1800) + (8*1200)) = 25800
-    command_with_repeats = SonyCommand(
-        address=command.address,
-        address_bits=command.address_bits,
-        command=command.command,
-        repeat_count=2,
-    )
-    timings_with_repeats = command_with_repeats.get_raw_timings()
-    assert timings_with_repeats == [
-        *expected_raw_timings,
-        *expected_raw_timings,
-        *expected_raw_timings,
-    ]
-
 
 def test_sony_command_get_raw_timings_15_bit() -> None:
     """Test SONY SIRC 15-bit framing for an 8-bit address."""
-    command = SonyCommand(address=0xA8, address_bits=8, command=0x02, repeat_count=0)
+    command = SonyCommand(address=0xA8, address_bits=8, command=0x02)
     timings = command.get_raw_timings()
 
     # 15-bit frame: leader high + 15 low/high pairs + trailer low
@@ -70,7 +56,7 @@ def test_sony_command_get_raw_timings_15_bit() -> None:
 
 def test_sony_command_get_raw_timings_20_bit() -> None:
     """Test SONY SIRC 20-bit framing for a 13-bit address."""
-    command = SonyCommand(address=0x1ABC, address_bits=13, command=0x34, repeat_count=0)
+    command = SonyCommand(address=0x1ABC, address_bits=13, command=0x34)
     timings = command.get_raw_timings()
 
     # 20-bit frame: leader high + 20 low/high pairs + trailer low

--- a/tests/commands/test_sony.py
+++ b/tests/commands/test_sony.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from infrared_protocols.commands.sony import SONYCommand
+from infrared_protocols.commands.sony import SonyCommand
 
 
 def test_sony_command_get_raw_timings_12_bit_standard() -> None:
@@ -37,13 +37,13 @@ def test_sony_command_get_raw_timings_12_bit_standard() -> None:
         600,
         -25800,
     ]
-    command = SONYCommand(address=0x01, address_bits=5, command=0x15, repeat_count=0)
+    command = SonyCommand(address=0x01, address_bits=5, command=0x15, repeat_count=0)
     timings = command.get_raw_timings()
     assert timings == expected_raw_timings
     assert command.modulation == 40000
 
     # Trailer low = 45000 - (2400 + (4*1800) + (8*1200)) = 25800
-    command_with_repeats = SONYCommand(
+    command_with_repeats = SonyCommand(
         address=command.address,
         address_bits=command.address_bits,
         command=command.command,
@@ -59,7 +59,7 @@ def test_sony_command_get_raw_timings_12_bit_standard() -> None:
 
 def test_sony_command_get_raw_timings_15_bit() -> None:
     """Test SONY SIRC 15-bit framing for an 8-bit address."""
-    command = SONYCommand(address=0xA8, address_bits=8, command=0x02, repeat_count=0)
+    command = SonyCommand(address=0xA8, address_bits=8, command=0x02, repeat_count=0)
     timings = command.get_raw_timings()
 
     # 15-bit frame: leader high + 15 low/high pairs + trailer low
@@ -70,7 +70,7 @@ def test_sony_command_get_raw_timings_15_bit() -> None:
 
 def test_sony_command_get_raw_timings_20_bit() -> None:
     """Test SONY SIRC 20-bit framing for a 13-bit address."""
-    command = SONYCommand(address=0x1ABC, address_bits=13, command=0x34, repeat_count=0)
+    command = SonyCommand(address=0x1ABC, address_bits=13, command=0x34, repeat_count=0)
     timings = command.get_raw_timings()
 
     # 20-bit frame: leader high + 20 low/high pairs + trailer low
@@ -97,4 +97,4 @@ def test_sony_command_rejects_out_of_range(
 ) -> None:
     """SONY SIRC fields must fit address<=13 bits and command<=7 bits."""
     with pytest.raises(ValueError):
-        SONYCommand(address=address, address_bits=address_bits, command=command)
+        SonyCommand(address=address, address_bits=address_bits, command=command)


### PR DESCRIPTION
- Add `SonyCommand` to process Sony SIRC protocol (also has unit test)
- Add PlayStation2 and PSX commands (based on above protocol)