### PR TITLE
feat: implement Sharp protocol & add Sharp AQUOS TV codes

### DIFF
--- a/infrared_protocols/codes/sharp/aquos_tv.py
+++ b/infrared_protocols/codes/sharp/aquos_tv.py
@@ -1,0 +1,49 @@
+"""Command codes for Sharp AQUOS TVs."""
+
+from enum import Enum
+
+from ...commands import Command
+from ...commands.sharp import SharpCommand
+
+
+class SharpAquosTVCode(Enum):
+    """Sharp AQUOS TV IR command codes.
+
+    Values are tuples of (address, command, extension) for SharpCommand.
+    """
+
+    POWER_TOGGLE = (1, 22, 1)
+    POWER_ON = (17, 74, 1)
+    POWER_OFF = (17, 75, 1)
+    NUM_1 = (1, 1, 1)
+    NUM_2 = (1, 2, 1)
+    NUM_3 = (1, 3, 1)
+    NUM_4 = (1, 4, 1)
+    NUM_5 = (1, 5, 1)
+    NUM_6 = (1, 6, 1)
+    NUM_7 = (1, 7, 1)
+    NUM_8 = (1, 8, 1)
+    NUM_9 = (1, 9, 1)
+    NUM_10 = (1, 10, 1)
+    NUM_11 = (1, 11, 1)
+    NUM_12 = (1, 12, 1)
+    CHANNEL_UP = (1, 17, 1)
+    CHANNEL_DOWN = (1, 18, 1)
+    SOURCE = (1, 19, 1)
+    VOLUME_UP = (1, 20, 1)
+    VOLUME_DOWN = (1, 21, 1)
+    MUTE = (1, 23, 1)
+    SLEEP = (1, 26, 1)
+    INFO = (1, 27, 1)
+    NAV_UP = (1, 87, 1)
+    NAV_DOWN = (1, 32, 1)
+    NAV_LEFT = (1, 215, 1)
+    NAV_RIGHT = (1, 216, 1)
+    OK = (1, 82, 1)
+    BACK = (1, 228, 1)
+    MENU = (1, 196, 1)
+
+    def to_command(self) -> Command:
+        """Convert the code to a SharpCommand."""
+        address, command, extension = self.value
+        return SharpCommand(address=address, command=command, extension=extension)

--- a/infrared_protocols/commands/sharp.py
+++ b/infrared_protocols/commands/sharp.py
@@ -1,0 +1,91 @@
+"""Sharp IR command."""
+
+from typing import override
+
+from . import Command
+
+_BIT_HIGH = 320
+_ZERO_LOW = 1000 - 320  # 680
+_ONE_LOW = 2000 - 320  # 1680
+_TRAILER_LOW = 40000
+
+
+class SharpCommand(Command):
+    """Sharp IR command."""
+
+    address: int
+    command: int
+    extension: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        extension: int = 0,
+        modulation: int = 38000,
+    ) -> None:
+        """Initialize the Sharp IR command.
+
+        :param address: The IR address for the Sharp command. (5 bits)
+        :param command: The IR command for the Sharp command. (8 bits)
+        :param extension: The extension bit for the Sharp command. (1 bit)
+        """
+        if not 0 <= address <= 0x1F:
+            raise ValueError(f"address must be in range 0-31, got {address}")
+        if not 0 <= command <= 0xFF:
+            raise ValueError(f"command must be in range 0-255, got {command}")
+        if extension not in (0, 1):
+            raise ValueError(f"extension must be 0 or 1, got {extension}")
+        super().__init__(modulation=modulation)
+        self.address = address
+        self.command = command
+        self.extension = extension
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Sharp command.
+
+        The Sharp protocol has no dedicated repeat code; a held button
+        retransmits the same full frame repeatedly.
+
+        Sharp protocol timing (in microseconds):
+        - No leader pulse
+        - Logical '0': 320µs high, 680µs low (1ms total)
+        - Logical '1': 320µs high, 1680µs low (2ms total)
+        - Trailer pulse: 320µs high, 40ms low (frame gap)
+
+        Frame format:
+        - Data frame (15 bits total):
+          - 5-bit address (LSB first)
+          - 8-bit command (LSB first)
+          - 1 extension bit
+          - check bit (0)
+        - Trailer pulse
+        - Inverted data frame (15 bits total):
+          - 5-bit address (unchanged)
+          - 8-bit command (inverted)
+          - 1 extension bit (inverted)
+          - check bit (1)
+        - Trailer pulse
+        """
+        # Build 15-bit data word (LSB first):
+        # bits 0-4: address, bits 5-12: command, bit 13: extension, bit 14: check (0)
+        data = self.address | (self.command << 5) | (self.extension << 13)
+        # Invert bits 5-14 for the second frame (address bits 0-4 stay the same)
+        idata = data ^ 0x7FE0
+
+        timings: list[int] = []
+
+        def _encode_bits(value: int) -> None:
+            for _ in range(15):
+                bit = value & 1
+                timings.append(_BIT_HIGH)
+                timings.append(-(_ONE_LOW if bit else _ZERO_LOW))
+                value >>= 1
+            timings.extend([_BIT_HIGH, -_TRAILER_LOW])
+
+        _encode_bits(data)
+        _encode_bits(idata)
+
+        return timings

--- a/tests/commands/test_sharp.py
+++ b/tests/commands/test_sharp.py
@@ -1,0 +1,169 @@
+"""Tests for the Sharp IR command."""
+
+import pytest
+
+from infrared_protocols.commands.sharp import SharpCommand
+
+_BIT_ZERO = [320, -680]
+_BIT_ONE = [320, -1680]
+
+
+class TestSharpCommandEncoding:
+    """Test SharpCommand.get_raw_timings()."""
+
+    def test_aquos_button_1(self) -> None:
+        """AQUOS TV button '1': address=1, command=1, extension=1."""
+        cmd = SharpCommand(address=1, command=1, extension=1)
+        assert cmd.get_raw_timings() == [
+            # region Address (5 bits, LSB first: 1,0,0,0,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            # endregion Address (5 bits, LSB first: 1,0,0,0,0)
+            # region Command (8 bits, LSB first: 1,0,0,0,0,0,0,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            # endregion Command (8 bits, LSB first: 1,0,0,0,0,0,0,0)
+            # region Extension and Check (2 bits, LSB first: 1,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            # endregion Extension and Check (2 bits, LSB first: 1,0)
+            320, -40000,  # Trailer
+            # region Address (5 bits, LSB first: 1,0,0,0,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            # endregion Address (5 bits, LSB first: 1,0,0,0,0)
+            # region Command inverted (8 bits, LSB first: 0,1,1,1,1,1,1,1)
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            # endregion Command inverted (8 bits, LSB first: 0,1,1,1,1,1,1,1)
+            # region Extension and Check inverted (2 bits, LSB first: 0,1)
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            # endregion Extension and Check inverted (2 bits, LSB first: 0,1)
+            320, -40000,  # Trailer
+        ]
+
+    def test_aquos_power_button(self) -> None:
+        """AQUOS TV power button: address=1, command=22, extension=1."""
+        cmd = SharpCommand(address=1, command=22, extension=1)
+        assert cmd.get_raw_timings() == [
+            # region Address (5 bits, LSB first: 1,0,0,0,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            # endregion Address (5 bits, LSB first: 1,0,0,0,0)
+            # region Command (8 bits, LSB first: 0,1,1,0,1,0,0,0)
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            # endregion Command (8 bits, LSB first: 0,1,1,0,1,0,0,0)
+            # region Extension and Check (2 bits, LSB first: 1,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            # endregion Extension and Check (2 bits, LSB first: 1,0)
+            320, -40000,  # Trailer
+            # region Address (5 bits, LSB first: 1,0,0,0,0)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            # endregion Address (5 bits, LSB first: 1,0,0,0,0)
+            # region Command inverted (8 bits, LSB first: 1,0,0,1,0,1,1,1)
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            *_BIT_ONE,
+            # endregion Command inverted (8 bits, LSB first: 1,0,0,1,0,1,1,1)
+            # region Extension and Check inverted (2 bits, LSB first: 0,1)
+            *_BIT_ZERO,
+            *_BIT_ONE,
+            # endregion Extension and Check inverted (2 bits, LSB first: 0,1)
+            320, -40000,  # Trailer
+        ]
+
+    def test_frame_length(self) -> None:
+        """Total timings: 2 frames × (15 bits × 2 + trailer × 2) = 64 values."""
+        cmd = SharpCommand(address=1, command=1, extension=1)
+        assert len(cmd.get_raw_timings()) == 64
+
+    def test_address_preserved_in_inverted_frame(self) -> None:
+        """Address bits must be identical in data and inverted data frames."""
+        cmd = SharpCommand(address=0x15, command=0)
+        timings = cmd.get_raw_timings()
+        # First frame: indices 0-29 (bits) + 30,31 (trailer)
+        data_bits = timings[:30]
+        # Second frame: indices 32-61 (bits) + 62,63 (trailer)
+        idata_bits = timings[32:62]
+        # First 5 bits (10 values) represent the address and must match
+        assert data_bits[:10] == idata_bits[:10]
+
+    def test_non_address_bits_inverted_in_inverted_frame(self) -> None:
+        """Command, extension, and check bits must be inverted in the second frame."""
+        cmd = SharpCommand(address=0x00, command=0xB4, extension=1)
+        timings = cmd.get_raw_timings()
+        # Bits 5-14 (command + extension + check): space values at odd indices
+        # within each frame. Space -680 = '0', -1680 = '1'.
+        data_spaces = [timings[n * 2 + 1] for n in range(5, 15)]
+        idata_spaces = [timings[32 + n * 2 + 1] for n in range(5, 15)]
+        invert = {-680: -1680, -1680: -680}
+        assert idata_spaces == [invert[s] for s in data_spaces]
+
+    def test_trailer_values(self) -> None:
+        """Both trailer pulses must be 320µs high, 40000µs low."""
+        cmd = SharpCommand(address=1, command=1, extension=1)
+        timings = cmd.get_raw_timings()
+        # Trailer after data frame
+        assert timings[30] == 320
+        assert timings[31] == -40000
+        # Trailer after inverted data frame
+        assert timings[62] == 320
+        assert timings[63] == -40000
+
+
+@pytest.mark.parametrize(
+    ("address", "command", "extension"),
+    [
+        (-1, 0x00, 0),
+        (0x20, 0x00, 0),
+        (0x00, -1, 0),
+        (0x00, 0x100, 0),
+        (0x00, 0x00, -1),
+        (0x00, 0x00, 2),
+    ],
+)
+def test_sharp_rejects_out_of_range(
+    address: int, command: int, extension: int
+) -> None:
+    """5-bit address, 8-bit command, 1-bit extension — anything else is invalid."""
+    with pytest.raises(ValueError):
+        SharpCommand(address=address, command=command, extension=extension)


### PR DESCRIPTION
- Add `SharpCommand` to process Sharp protocol (also has unit test)
- Add Sharp AQUOS TV commands (based on above protocol)
  - This series has been ongoing for many years, and the IR protocol has been changed (ex. AEHA, 家製協 protocol) along the way. Some models may not work with this command, but identifying them is difficult.