### PR TITLE
fix: ignore trailing timings after NEC end pulse instead of rejecting frame

### DIFF
--- a/infrared_protocols/commands/nec.py
+++ b/infrared_protocols/commands/nec.py
@@ -138,8 +138,8 @@ class NECCommand(Command):
         # of the low byte to determine if it was originally a standard 8-bit address.
         address = address_low | (address_high << 8)
 
-        # Count repeat codes after the end pulse. Any remaining timings must be
-        # complete repeat frames; otherwise this is not a valid NEC command.
+        # Count repeat codes after the end pulse. Counting stops at the first
+        # mismatch or truncated repeat frame; any remaining timings are ignored.
         repeat_count = cls._count_repeat_codes(timings, 67)
         return cls(address=address, command=command_byte, repeat_count=repeat_count)
 

--- a/infrared_protocols/commands/nec.py
+++ b/infrared_protocols/commands/nec.py
@@ -141,9 +141,6 @@ class NECCommand(Command):
         # Count repeat codes after the end pulse. Any remaining timings must be
         # complete repeat frames; otherwise this is not a valid NEC command.
         repeat_count = cls._count_repeat_codes(timings, 67)
-        if repeat_count is None:
-            return None
-
         return cls(address=address, command=command_byte, repeat_count=repeat_count)
 
     @staticmethod
@@ -167,19 +164,17 @@ class NECCommand(Command):
         return None
 
     @staticmethod
-    def _count_repeat_codes(timings: list[int], start_index: int) -> int | None:
+    def _count_repeat_codes(timings: list[int], start_index: int) -> int:
         """Count NEC repeat codes starting from the given index.
 
         A repeat code consists of a frame gap, a leader burst (9000µs high,
-        2250µs low), and an end pulse (562µs high). Returns None if trailing
-        timings do not exactly match complete repeat codes.
+        2250µs low), and an end pulse (562µs high). Counting stops at the first
+        mismatch or truncated trailing frame; any remaining timings are ignored.
         """
         count = 0
         i = start_index
         gap = INITIAL_FRAME_GAP
-        while i < len(timings):
-            if i + 3 >= len(timings):
-                return None
+        while (i + 3) < len(timings):
             if (
                 NECCommand._is_close(-timings[i], gap)
                 and NECCommand._is_close(timings[i + 1], LEADER_HIGH)
@@ -190,5 +185,5 @@ class NECCommand(Command):
                 i += 4
                 gap = FRAME_GAP
             else:
-                return None
+                return count
         return count

--- a/tests/commands/test_nec.py
+++ b/tests/commands/test_nec.py
@@ -252,13 +252,25 @@ def test_nec_command_from_raw_timings_within_tolerance() -> None:
         pytest.param(
             [*STANDARD_FRAME[:65], -562, *STANDARD_FRAME[66:]], id="invalid_checksum"
         ),
-        pytest.param([*STANDARD_FRAME, -12345], id="trailing_garbage"),
-        pytest.param([*STANDARD_FRAME, -41000, 9000], id="incomplete_repeat"),
-        pytest.param(
-            [*STANDARD_FRAME, -100, 9000, -2250, 562], id="invalid_repeat_gap"
-        ),
     ],
 )
 def test_nec_command_from_raw_timings_invalid(timings: list[int]) -> None:
     """Test from_raw_timings returns None for malformed inputs."""
     assert NECCommand.from_raw_timings(timings) is None
+
+
+@pytest.mark.parametrize(
+    "trailing",
+    [
+        pytest.param([-12345], id="trailing_garbage"),
+        pytest.param([-41000, 9000], id="incomplete_repeat"),
+        pytest.param([-100, 9000, -2250, 562], id="invalid_repeat_gap"),
+    ],
+)
+def test_nec_command_from_raw_timings_ignores_trailing(trailing: list[int]) -> None:
+    """Test that trailing timings that don't form a valid repeat code are ignored."""
+    command = NECCommand.from_raw_timings([*STANDARD_FRAME, *trailing])
+    assert command is not None
+    assert command.address == STANDARD_DECODED_ADDRESS
+    assert command.command == COMMAND
+    assert command.repeat_count == 0

--- a/tests/commands/test_nec.py
+++ b/tests/commands/test_nec.py
@@ -260,17 +260,20 @@ def test_nec_command_from_raw_timings_invalid(timings: list[int]) -> None:
 
 
 @pytest.mark.parametrize(
-    "trailing",
+    ("trailing", "expected_repeat_count"),
     [
-        pytest.param([-12345], id="trailing_garbage"),
-        pytest.param([-41000, 9000], id="incomplete_repeat"),
-        pytest.param([-100, 9000, -2250, 562], id="invalid_repeat_gap"),
+        pytest.param([-12345], 0, id="trailing_garbage"),
+        pytest.param([-41000, 9000], 0, id="incomplete_repeat"),
+        pytest.param([-100, 9000, -2250, 562], 0, id="invalid_repeat_gap"),
+        pytest.param([*TWO_REPEATS_TAIL, -12345], 2, id="repeats_then_trailing_garbage"),
     ],
 )
-def test_nec_command_from_raw_timings_ignores_trailing(trailing: list[int]) -> None:
-    """Test that trailing timings that don't form a valid repeat code are ignored."""
+def test_nec_command_from_raw_timings_ignores_trailing(
+    trailing: list[int], expected_repeat_count: int
+) -> None:
+    """Test that invalid trailing timings are ignored without dropping valid repeats."""
     command = NECCommand.from_raw_timings([*STANDARD_FRAME, *trailing])
     assert command is not None
     assert command.address == STANDARD_DECODED_ADDRESS
     assert command.command == COMMAND
-    assert command.repeat_count == 0
+    assert command.repeat_count == expected_repeat_count


### PR DESCRIPTION
NEC `from_raw_timings` now ignores trailing timings that don't form a valid repeat code, instead of rejecting the whole frame. Real-world captures often include trailing noise or a bigger "low" timing at the end (seen it when testing with ESPHome).
