### PR TITLE
feat: add codes for Tween Light LED Strip controller

### DIFF
--- a/infrared_protocols/codes/tween_light/led_strip.py
+++ b/infrared_protocols/codes/tween_light/led_strip.py
@@ -1,0 +1,50 @@
+"""Command codes for Tween Light LED Strip.
+
+Tween light is a brand marketed by the european home improvement retail chain BAUHAUS.
+The LED strip comes with a 24-key remote control, which is also sold with many other
+no-name LED controllers.
+
+https://www.bauhaus.info/led-streifen/tween-light-led-band/p/30293612
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class TweenLightLEDStripCode(IntEnum):
+    """Tween Light LED Strip IR command codes."""
+
+    ON = 0xFC03
+    OFF = 0xFD02
+    BRIGHTNESS_UP = 0xFF00
+    BRIGHTNESS_DOWN = 0xFE01
+    FLASH = 0xF40B
+    STROBE = 0xF00F
+    FADE = 0xEC13
+    SMOOTH = 0xE817
+    RED = 0xFB04
+    GREEN = 0xFA05
+    BLUE = 0xF906
+    WHITE = 0xF708
+    TOMATO = 0xF708
+    LIGHT_GREEN = 0xF609
+    SKY_BLUE = 0xF906
+    ORANGE_RED = 0xF30C
+    CYAN = 0xF20D
+    REBECCA_PURPLE = 0xF10E
+    ORANGE = 0xEF10
+    TURQUOISE = 0xEE11
+    PURPLE = 0xED12
+    YELLOW = 0xEB14
+    DARK_CYAN = 0xEA15
+    PLUM = 0xE916
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build a NEC command."""
+        return NECCommand(
+            address=0xEF00,
+            command=self.value,
+            repeat_count=repeat_count,
+        )


### PR DESCRIPTION
Adds codes for [Tween Light LED Strip](https://www.bauhaus.info/led-streifen/tween-light-led-band/p/30293612). 

Tween Light is a brand marketed by the European home improvement retail chain BAUHAUS. 

This IR remote is also very common and shipped with different no-name LED controllers that can be found for example on Aliexpress or Amazon ([1](https://amzn.eu/d/0dk7xSNn), [2](https://amzn.eu/d/0dk7xSNn)). These codes should be compatible with most of these controllers that come with a 24-key remote. There are some similar, but less common [24-key remotes](https://kno.wled.ge/interfaces/json-ir/json_infrared/) that use different IR codes.

There are other Tween Light lamps with remotes, like the [ceiling light](https://www.bauhaus.info/deckenlampen/tween-light-led-deckenleuchte-rund-skyler-star-rgbw/p/25942682) and [LED-panel](https://www.bauhaus.info/led-panels/tween-light-led-panel-rgb-rc-cct-dim/p/28771113), but those ship with a different remote, so these could be added in a future PR if they are also infrared.