### PR TITLE
Add Samsung AC IR encoder and tests

### DIFF
--- a/infrared_protocols/codes/samsung/ac.py
+++ b/infrared_protocols/codes/samsung/ac.py
@@ -1,0 +1,85 @@
+"""Command codes and state builders for Samsung Air Conditioners."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ...commands import Command
+
+
+@dataclass(frozen=True)
+class SamsungACProtocolCommand(Command):
+    """Concrete implementation of the Samsung AC IR Command."""
+
+    modulation: int
+    timings: list[int]
+
+    def get_raw_timings(self) -> list[int]:
+        """Return the calculated raw IR timings with negative space markers."""
+        return self.timings
+
+
+@dataclass(frozen=True)
+class SamsungACCommand:
+    """Builder for Samsung AC IR commands (14-byte extended protocol)."""
+
+    hvac_mode: Literal["off", "cool", "heat", "dry", "fan_only"]
+    target_temperature: int
+    fan_mode: Literal["auto", "low", "medium", "high"]
+
+    def to_command(self) -> Command:
+        """Compile the logical state into a 14-byte payload and generate the IR Command."""
+        payload = [0x00] * 14
+
+        # Fixed header bytes for Samsung AC protocol
+        payload[0] = 0x02
+        payload[1] = 0x92
+
+        # Temperature encoding (standard range 16-30°C mapped as temp - 16)
+        target_temp = max(16, min(30, self.target_temperature))
+        payload[5] = (target_temp - 16) << 4
+
+        # HVAC Mode encoding
+        if self.hvac_mode == "off":
+            payload[6] = 0x00
+        elif self.hvac_mode == "cool":
+            payload[6] = 0x01
+        elif self.hvac_mode == "heat":
+            payload[6] = 0x02
+        else:
+            payload[6] = 0x03  # Default to Dry / Fan Only
+
+        # Fan Speed encoding
+        if self.fan_mode == "high":
+            payload[7] = 0xA0
+        elif self.fan_mode == "medium":
+            payload[7] = 0x80
+        else:
+            payload[7] = 0x40  # Auto / Low
+
+        # Checksum calculation (XOR of significant data bytes)
+        checksum = 0
+        for byte in payload[2:13]:
+            checksum ^= byte
+        payload[13] = checksum
+
+        # Generate physical raw timings (standard 38kHz carrier frequency)
+        raw_timings: list[int] = []
+
+        # Leader Pulse: 3000µs Mark, -3000µs Space (aligned to library style)
+        raw_timings.extend([3000, -3000])
+
+        # Bit blast (LSB first for each byte)
+        for byte in payload:
+            for i in range(8):
+                bit = (byte >> i) & 1
+                if bit == 1:
+                    # Bit 1: 600µs Mark, -1400µs Space
+                    raw_timings.extend([600, -1400])
+                else:
+                    # Bit 0: 600µs Mark, -400µs Space
+                    raw_timings.extend([600, -400])
+
+        # Final Stop Bit (only a pulse, no ending gap required for single frames)
+        raw_timings.extend([600])
+
+        return SamsungACProtocolCommand(modulation=38000, timings=raw_timings)

--- a/tests/test_samsung_ac.py
+++ b/tests/test_samsung_ac.py
@@ -1,0 +1,63 @@
+"""Tests for the Samsung AC IR command encoder."""
+
+from infrared_protocols.codes.samsung.ac import SamsungACCommand
+
+
+def test_samsung_ac_command_get_raw_timings() -> None:
+    """Test Samsung AC command raw timings compilation."""
+    # Setup condition: Cool mode, 24°C, Fan High
+    # Expected bytes layout based on the protocol:
+    # byte 0: 0x02, byte 1: 0x92
+    # byte 5: (24 - 16) << 4 = 8 << 4 = 0x80
+    # byte 6: 0x01 (cool)
+    # byte 7: 0xA0 (high)
+    # bytes 2..4, 8..12: 0x00
+    # Checksum: 0x00 ^ 0x00 ^ 0x00 ^ 0x80 ^ 0x01 ^ 0xA0 ^ ... = 0x21
+    # Full payload to bit-blast: [0x02, 0x92, 0x00, 0x00, 0x00, 0x80, 0x01, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21]
+    
+    expected_raw_timings = [
+        # Leader pulse
+        3000,
+        -3000,
+        # Byte 0: 0x02 (LSB first: 0,1,0,0,0,0,0,0)
+        600, -400, 600, -1400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 1: 0x92 (LSB first: 0,1,0,0,1,0,0,1)
+        600, -400, 600, -1400, 600, -400, 600, -400, 600, -1400, 600, -400, 600, -400, 600, -1400,
+        # Byte 2: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 3: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 4: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 5: 0x80 (LSB first: 0,0,0,0,0,0,0,1)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -1400,
+        # Byte 6: 0x01 (LSB first: 1,0,0,0,0,0,0,0)
+        600, -1400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 7: 0xA0 (LSB first: 0,0,0,0,0,1,0,1)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -1400, 600, -400, 600, -1400,
+        # Byte 8: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 9: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 10: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 11: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 12: 0x00 (all zeros)
+        600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -400,
+        # Byte 13: 0x21 (LSB first: 1,0,0,0,0,1,0,0) -> Checksum
+        600, -1400, 600, -400, 600, -400, 600, -400, 600, -400, 600, -1400, 600, -400, 600, -400,
+        # End pulse
+        600,
+    ]
+
+    builder = SamsungACCommand(
+        hvac_mode="cool",
+        target_temperature=24,
+        fan_mode="high",
+    )
+    command = builder.to_command()
+    timings = command.get_raw_timings()
+
+    assert timings == expected_raw_timings
+    assert command.modulation == 38000


### PR DESCRIPTION
Implement SamsungACCommand and SamsungACProtocolCommand to build 14-byte Samsung AC payloads (fixed header, temperature mapping, HVAC and fan encodings, XOR checksum) and generate raw IR timings (LSB-first bit-blast with leader pulse, 38 kHz modulation). Add unit test verifying the exact timing sequence for cool mode, 24°C, high fan and the computed checksum.