### PR TITLE
fix: relax Python requirement to >=3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.14.2"
+requires-python = ">=3.14"
 
 [project.urls]
 "Homepage" = "https://github.com/home-assistant-libs/infrared-protocols"


### PR DESCRIPTION
https://github.com/home-assistant-libs/infrared-protocols/pull/50 removed Python 3.13 support by requiring Python 3.14.2. This also means that Python 3.14.x versions with x < 2 are not compatible with this library anymore.

As it's unusual for a library to require a certain Python patch release, and with this currently breaking the Home Assistant Core wheel builder due to it still running on Python 3.14.0, this PR relaxes the requirement to just Python 3.14.