### PR TITLE
feat(commands): add pronto protocol implementation

### DIFF
--- a/infrared_protocols/commands/pronto.py
+++ b/infrared_protocols/commands/pronto.py
@@ -1,0 +1,146 @@
+"""Pronto IR command code format."""
+
+import struct
+from textwrap import wrap
+from typing import Self, override
+
+from . import Command
+
+PRONTO_PREAMBLE_LEARNED_TOKEN = b"\x00\x00"
+# To get the unit pulse length in microseconds,
+# divide 1000 * 1000 (microseconds per second) by reference frequency
+PRONTO_REFERENCE_FREQUENCY = 4145146
+PRONTO_DEFAULT_FREQUENCY = 38000
+
+
+class ProntoCommand(Command):
+    """Pronto IR command.
+
+    A pronto code consists of a 4 word preamble and timing data.
+    A data word of pronto is 2 bytes long.
+    Two data words (4 bytes) encode one content bit.
+    The preamble consists of:
+    1 word indicating the token source (currently supported: learned).
+    1 word indicating the modulation frequency.
+    1 word indicating the length of the timing data in content bits.
+    1 word indicating the amount of repeats of the timing data.
+    After the preamble, the timing data follows in pairs of two words
+    (mark and space duration).
+
+    Most of the code has been ported from the ESPHome sources at
+    https://github.com/esphome/esphome/blob/dev/esphome/components/remote_base/pronto_protocol.cpp.
+    """
+
+    timing_data: bytes
+
+    def __init__(
+        self,
+        *,
+        timing_data: bytes,
+        modulation: int = PRONTO_DEFAULT_FREQUENCY,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Pronto IR command."""
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.timing_data = timing_data
+
+    def __repr__(self) -> str:
+        """Get string representation for this pronto code."""
+        content_bytes_hex = b"".join(
+            [
+                PRONTO_PREAMBLE_LEARNED_TOKEN,
+                ProntoCommand._int_to_pronto(
+                    value=round(PRONTO_REFERENCE_FREQUENCY / self.modulation)
+                ),  # Modulation
+                ProntoCommand._int_to_pronto(
+                    value=int(len(self.timing_data) / 4)
+                ),  # in content bits
+                ProntoCommand._int_to_pronto(value=self.repeat_count),  # repeats
+                self.timing_data,
+            ]
+        ).hex()
+        return " ".join(wrap(content_bytes_hex, 4))
+
+    @staticmethod
+    def _int_to_pronto(value: int) -> bytes:
+        return struct.pack(">h", value)
+
+    @staticmethod
+    def _pronto_to_int(pronto_block: bytes) -> int:
+        return struct.unpack(">h", pronto_block)[0]
+
+    @staticmethod
+    def _time_base(modulation: int) -> float:
+        """Calculate base pulse length in microseconds for a given modulation."""
+        return 1000000 / modulation
+
+    @staticmethod
+    def _compensate_duration(value: int, time_base: float) -> int:
+        """Compensate positive/negative durations to positive ones."""
+        if value > 0:
+            result = value - 20
+        else:
+            result = -value + 20
+        return round((result + time_base / 2) / time_base)
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Pronto command.
+
+        Durations are encoded in the pronto timing data and only need to be converted.
+        """
+        time_base = ProntoCommand._time_base(self.modulation)
+        return [
+            symbol
+            for value in zip(
+                self.timing_data[::4],
+                self.timing_data[1::4],
+                self.timing_data[2::4],
+                self.timing_data[3::4],
+                strict=True,
+            )
+            for symbol in (
+                # mark
+                min(
+                    round(
+                        ProntoCommand._pronto_to_int(pronto_block=bytes(value[:2]))
+                        * time_base
+                    ),
+                    0xFFFF,
+                ),
+                # space
+                -min(
+                    round(
+                        ProntoCommand._pronto_to_int(pronto_block=bytes(value[2:]))
+                        * time_base
+                    ),
+                    0xFFFF,
+                ),
+            )
+        ] * (self.repeat_count + 1)
+
+    @classmethod
+    def from_raw_timings(
+        cls, timings: list[int], modulation: int | None = None
+    ) -> Self:
+        """Decode raw IR timings into a ProntoCommand.
+
+        If modulation is None, the typical 38000 kHz are used.
+        Returns a ProntoCommand.
+        """
+        if modulation is None:
+            modulation = PRONTO_DEFAULT_FREQUENCY
+        time_base = ProntoCommand._time_base(modulation=modulation)
+        timing_data = b"".join(
+            ProntoCommand._int_to_pronto(
+                value=ProntoCommand._compensate_duration(
+                    value=timing, time_base=time_base
+                )
+            )
+            for timing in timings
+        )
+        return cls(
+            timing_data=timing_data,
+            modulation=modulation,
+            repeat_count=0,
+        )

--- a/tests/commands/test_pronto.py
+++ b/tests/commands/test_pronto.py
@@ -1,0 +1,37 @@
+from infrared_protocols.commands.pronto import ProntoCommand
+
+TEST_DATA_KNOWN_GOOD_RAW_TIMINGS = [
+    9100, -4446, 598, -494, 598, -494, 598, -494, 598, -1612, 598, -494, 598, -494, 598,
+    -1612, 598, -494, 598, -494, 598, -1612, 598, -494, 598, -494, 598, -494, 598, -494,
+    598, -494, 598, -1612, 598, -1612, 598, -494, 598, -494, 598, -494, 598, -494, 598,
+    -494, 598, -494, 598, -1612, 598, -494, 598, -494, 598, -494, 598, -1612, 598, -494,
+    598, -494, 598, -494, 598, -494, 598, -9984
+]
+TEST_DATA_KNOWN_GOOD_MODULATION = 38000
+TEST_DATA_KNOWN_GOOD_REPEATS = 0
+TEST_DATA_KNOWN_GOOD_PRONTO = b'\x01Z\x00\xaa\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x01}'
+TEST_DATA_KNOWN_GOOD_PRONTO_REPR = "0000 006d 0022 0000 015a 00aa 0016 0014 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 0014 0016 0014 0016 0014 0016 003f 0016 003f 0016 0014 0016 0014 0016 0014 0016 0014 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 0014 0016 0014 0016 017d"
+
+def test_encode_pronto_from_timing():
+    pronto = ProntoCommand.from_raw_timings(TEST_DATA_KNOWN_GOOD_RAW_TIMINGS)
+    assert pronto.modulation == TEST_DATA_KNOWN_GOOD_MODULATION
+    assert pronto.repeat_count == TEST_DATA_KNOWN_GOOD_REPEATS
+    assert pronto.timing_data == TEST_DATA_KNOWN_GOOD_PRONTO
+
+def test_decode_pronto_to_timing():
+    pronto = ProntoCommand(timing_data=TEST_DATA_KNOWN_GOOD_PRONTO, modulation=TEST_DATA_KNOWN_GOOD_MODULATION, repeat_count=TEST_DATA_KNOWN_GOOD_REPEATS)
+    assert pronto.modulation == 38000
+    assert pronto.repeat_count == TEST_DATA_KNOWN_GOOD_REPEATS
+    assert all(abs(calculated - expected) < 2 * ProntoCommand._time_base(modulation=pronto.modulation) for calculated, expected in zip(pronto.get_raw_timings(), TEST_DATA_KNOWN_GOOD_RAW_TIMINGS, strict=True))
+
+def test_pronto_repr():
+    pronto = ProntoCommand.from_raw_timings(TEST_DATA_KNOWN_GOOD_RAW_TIMINGS)
+    assert repr(pronto) == TEST_DATA_KNOWN_GOOD_PRONTO_REPR
+
+def test_pronto_repeats():
+    # Repeats only work correctly if pronto is constructed using the default constructor, not by using ProntoCommand.from_raw_timings.
+    pronto = ProntoCommand(timing_data=TEST_DATA_KNOWN_GOOD_PRONTO, modulation=TEST_DATA_KNOWN_GOOD_MODULATION, repeat_count=2)
+    assert pronto.repeat_count == 2
+    # 1 base + 2 repeats
+    assert len(pronto.get_raw_timings()) == (1 + 2) * len(TEST_DATA_KNOWN_GOOD_RAW_TIMINGS)
+    assert all(abs(calculated - expected) < 2 * ProntoCommand._time_base(modulation=pronto.modulation) for calculated, expected in zip(pronto.get_raw_timings(), TEST_DATA_KNOWN_GOOD_RAW_TIMINGS * (1 + 2), strict=True))


### PR DESCRIPTION
Hello!

As the HomeAssistant documentation already mentions a Pronto De/Encoder (which I sadly couldn't find), I thought about adding one.
Most code is based on the awesome work of ESPHome, where I was able to read into the protocol specifics, magic values, and how to perform the calculations.
The only limitation I know of is that the only available Pronto Code type is "learned, modulated". ESPHome also supports `learned, unmodulated`, but also states there are some more options. Either way, that should be rather easy to add once a use case arrives.

Thank you for your time and work on HomeAssistant!
