### PR TITLE
feat: IR codes for Anthem MRX x20/x40 and AVM 60/70/90 models. 

### DIFF
--- a/infrared_protocols/codes/anthem/models.py
+++ b/infrared_protocols/codes/anthem/models.py
@@ -1,0 +1,176 @@
+"""Known Anthem MRX/AVM models and the IR codes each one accepts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from infrared_protocols.codes.anthem.mrx_x20_x40_avm_x import AnthemCode
+
+
+@dataclass(frozen=True, slots=True)
+class AnthemModel:
+    """An Anthem MRX/AVM model and the IR codes it accepts."""
+
+    name: str
+    codes: frozenset[AnthemCode]
+
+
+# Common code sets reused across models.
+
+_BASE = frozenset(
+    {
+        AnthemCode.ON,
+        AnthemCode.STANDBY,
+        AnthemCode.BASS,
+        AnthemCode.DIM,
+        AnthemCode.BALANCE,
+        AnthemCode.TREBLE,
+        AnthemCode.LEVEL,
+        AnthemCode.NUM_1,
+        AnthemCode.NUM_2,
+        AnthemCode.NUM_3,
+        AnthemCode.NUM_4,
+        AnthemCode.NUM_5,
+        AnthemCode.NUM_6,
+        AnthemCode.NUM_7,
+        AnthemCode.NUM_8,
+        AnthemCode.NUM_9,
+        AnthemCode.NUM_0,
+        AnthemCode.PRESET,
+        AnthemCode.INPUT_CYCLE,
+        AnthemCode.SETUP_MENU,
+        AnthemCode.INFO,
+        AnthemCode.CURSOR_LEFT,
+        AnthemCode.CURSOR_UP,
+        AnthemCode.SELECT,
+        AnthemCode.CURSOR_RIGHT,
+        AnthemCode.CURSOR_DOWN,
+        AnthemCode.CLEAR,
+        AnthemCode.DYNAMICS,
+        AnthemCode.MODE,
+        AnthemCode.LAST,
+        AnthemCode.VOLUME_UP,
+        AnthemCode.VOLUME_DOWN,
+        AnthemCode.MUTE,
+        AnthemCode.LIP_SYNC,
+        AnthemCode.PAGE_PRESET_UP,
+        AnthemCode.PAGE_PRESET_DOWN,
+        AnthemCode.INPUT_1,
+        AnthemCode.INPUT_2,
+        AnthemCode.INPUT_3,
+        AnthemCode.INPUT_4,
+        AnthemCode.INPUT_5,
+        AnthemCode.INPUT_6,
+        AnthemCode.INPUT_7,
+        AnthemCode.INPUT_8,
+        AnthemCode.INPUT_9,
+        AnthemCode.INPUT_10,
+        AnthemCode.INPUT_11,
+        AnthemCode.INPUT_12,
+        AnthemCode.INPUT_13,
+        AnthemCode.INPUT_14,
+        AnthemCode.INPUT_15,
+        AnthemCode.INPUT_16,
+        AnthemCode.INPUT_17,
+        AnthemCode.INPUT_18,
+        AnthemCode.INPUT_19,
+        AnthemCode.INPUT_20,
+        AnthemCode.ZONE2_ON,
+        AnthemCode.ZONE2_STANDBY,
+        AnthemCode.ZONE2_VOLUME_UP,
+        AnthemCode.ZONE2_VOLUME_DOWN,
+        AnthemCode.ZONE2_MUTE,
+        AnthemCode.ZONE2_INPUT_CYCLE,
+        AnthemCode.ZONE2_PRESET_UP,
+        AnthemCode.ZONE2_PRESET_DOWN,
+        AnthemCode.ZONE2_INPUT_1,
+        AnthemCode.ZONE2_INPUT_2,
+        AnthemCode.ZONE2_INPUT_3,
+        AnthemCode.ZONE2_INPUT_4,
+        AnthemCode.ZONE2_INPUT_5,
+        AnthemCode.ZONE2_INPUT_6,
+        AnthemCode.ZONE2_INPUT_7,
+        AnthemCode.ZONE2_INPUT_8,
+        AnthemCode.ZONE2_INPUT_9,
+        AnthemCode.ZONE2_INPUT_10,
+        AnthemCode.ZONE2_INPUT_11,
+        AnthemCode.ZONE2_INPUT_12,
+        AnthemCode.ZONE2_INPUT_13,
+        AnthemCode.ZONE2_INPUT_14,
+        AnthemCode.ZONE2_INPUT_15,
+        AnthemCode.ZONE2_INPUT_16,
+        AnthemCode.ZONE2_INPUT_17,
+        AnthemCode.ZONE2_INPUT_18,
+        AnthemCode.ZONE2_INPUT_19,
+        AnthemCode.ZONE2_INPUT_20,
+    }
+)
+
+#: Inputs 21-30. Per Anthem's documentation, the factory MRX x10 remote does
+#: not include these -- they exist for programmable remotes on MRX x20, AVM 60,
+#: and the newer MRX x40 / AVM 70 / AVM 90 generation including 4k and 8k models.
+_EXTENDED_INPUTS = frozenset(
+    {
+        AnthemCode.INPUT_21,
+        AnthemCode.INPUT_22,
+        AnthemCode.INPUT_23,
+        AnthemCode.INPUT_24,
+        AnthemCode.INPUT_25,
+        AnthemCode.INPUT_26,
+        AnthemCode.INPUT_27,
+        AnthemCode.INPUT_28,
+        AnthemCode.INPUT_29,
+        AnthemCode.INPUT_30,
+        AnthemCode.ZONE2_INPUT_21,
+        AnthemCode.ZONE2_INPUT_22,
+        AnthemCode.ZONE2_INPUT_23,
+        AnthemCode.ZONE2_INPUT_24,
+        AnthemCode.ZONE2_INPUT_25,
+        AnthemCode.ZONE2_INPUT_26,
+        AnthemCode.ZONE2_INPUT_27,
+        AnthemCode.ZONE2_INPUT_28,
+        AnthemCode.ZONE2_INPUT_29,
+        AnthemCode.ZONE2_INPUT_30,
+    }
+)
+
+
+GENERIC = AnthemModel(
+    name="Generic Anthem MRX/AVM",
+    codes=_BASE | _EXTENDED_INPUTS,
+)
+
+
+MRX_310 = AnthemModel(name="MRX 310", codes=_BASE)
+MRX_510 = AnthemModel(name="MRX 510", codes=_BASE)
+MRX_710 = AnthemModel(name="MRX 710", codes=_BASE)
+
+MRX_520 = AnthemModel(name="MRX 520", codes=_BASE | _EXTENDED_INPUTS)
+MRX_720 = AnthemModel(name="MRX 720", codes=_BASE | _EXTENDED_INPUTS)
+MRX_1120 = AnthemModel(name="MRX 1120", codes=_BASE | _EXTENDED_INPUTS)
+AVM_60 = AnthemModel(name="AVM 60", codes=_BASE | _EXTENDED_INPUTS)
+
+MRX_540 = AnthemModel(name="MRX 540", codes=_BASE | _EXTENDED_INPUTS)
+MRX_740 = AnthemModel(name="MRX 740", codes=_BASE | _EXTENDED_INPUTS)
+MRX_1140 = AnthemModel(name="MRX 1140", codes=_BASE | _EXTENDED_INPUTS)
+AVM_70 = AnthemModel(name="AVM 70", codes=_BASE | _EXTENDED_INPUTS)
+AVM_90 = AnthemModel(name="AVM 90", codes=_BASE | _EXTENDED_INPUTS)
+
+
+"""All known Anthem MRX/AVM models, for iteration. Generic is first so
+    integrations using this list as a UI source default to the catch-all."""
+ALL_MODELS: tuple[AnthemModel, ...] = (
+    GENERIC,
+    MRX_310,
+    MRX_510,
+    MRX_710,
+    MRX_520,
+    MRX_720,
+    MRX_1120,
+    AVM_60,
+    MRX_540,
+    MRX_740,
+    MRX_1140,
+    AVM_70,
+    AVM_90,
+)

--- a/infrared_protocols/codes/anthem/mrx_x20_x40_avm_x.py
+++ b/infrared_protocols/codes/anthem/mrx_x20_x40_avm_x.py
@@ -1,0 +1,142 @@
+"""IR command codes for Anthem MRX/AVM receivers and pre-amplifiers.
+
+Codes are identical across the Anthem MRX/AVM lineup (MRX 310/510/710,
+MRX 520/720/1120, MRX x40, AVM 60, AVM 70/90) -- verified by decoding the
+manufacturer's published IR hex/Pronto tables for both the MRX x10/x20/AVM 60
+generation and the newer 4K/8K (MRX x40, AVM 70/90) generation and confirming
+they encode to the same NEC address/command pairs.
+
+This was verified with Anthem Technical Support.
+"""
+
+from enum import Enum
+
+from infrared_protocols.commands import Command
+from infrared_protocols.commands.nec import NECCommand
+
+_ADDR_MAIN = 0x6A85
+_ADDR_EXT = 0x9A85
+
+
+class AnthemCode(Enum):
+    """IR command code for an Anthem MRX/AVM receiver or pre-amplifier.
+
+    The tuple value is ``(address, command)`` for the extended NEC protocol.
+    """
+
+    # Main Zone
+    ON = (_ADDR_MAIN, 0x97)
+    STANDBY = (_ADDR_MAIN, 0x93)
+    BASS = (_ADDR_MAIN, 0x6F)
+    DIM = (_ADDR_MAIN, 0xF3)
+    BALANCE = (_ADDR_EXT, 0x72)
+    TREBLE = (_ADDR_MAIN, 0x70)
+    LEVEL = (_ADDR_MAIN, 0x39)
+    NUM_1 = (_ADDR_MAIN, 0x80)
+    NUM_2 = (_ADDR_MAIN, 0x81)
+    NUM_3 = (_ADDR_MAIN, 0x82)
+    NUM_4 = (_ADDR_MAIN, 0x83)
+    NUM_5 = (_ADDR_MAIN, 0x84)
+    NUM_6 = (_ADDR_MAIN, 0x85)
+    NUM_7 = (_ADDR_MAIN, 0x86)
+    NUM_8 = (_ADDR_MAIN, 0x87)
+    NUM_9 = (_ADDR_MAIN, 0x88)
+    NUM_0 = (_ADDR_MAIN, 0x89)
+    PRESET = (_ADDR_MAIN, 0x6E)
+    INPUT_CYCLE = (_ADDR_MAIN, 0x9B)
+    SETUP_MENU = (_ADDR_MAIN, 0x3E)
+    INFO = (_ADDR_MAIN, 0x37)
+    CURSOR_LEFT = (_ADDR_MAIN, 0x60)
+    CURSOR_UP = (_ADDR_MAIN, 0x5D)
+    SELECT = (_ADDR_MAIN, 0x96)
+    CURSOR_RIGHT = (_ADDR_MAIN, 0x5F)
+    CURSOR_DOWN = (_ADDR_MAIN, 0x5E)
+    CLEAR = (_ADDR_EXT, 0x96)
+    DYNAMICS = (_ADDR_MAIN, 0x3D)
+    MODE = (_ADDR_MAIN, 0x2D)
+    LAST = (_ADDR_EXT, 0x94)
+    VOLUME_UP = (_ADDR_MAIN, 0x9F)
+    VOLUME_DOWN = (_ADDR_MAIN, 0x9E)
+    MUTE = (_ADDR_MAIN, 0x99)
+    LIP_SYNC = (_ADDR_EXT, 0x92)
+    PAGE_PRESET_UP = (_ADDR_EXT, 0x9B)
+    PAGE_PRESET_DOWN = (_ADDR_EXT, 0x9C)
+    INPUT_1 = (_ADDR_MAIN, 0x0F)
+    INPUT_2 = (_ADDR_MAIN, 0x8C)
+    INPUT_3 = (_ADDR_MAIN, 0x90)
+    INPUT_4 = (_ADDR_MAIN, 0x25)
+    INPUT_5 = (_ADDR_MAIN, 0x14)
+    INPUT_6 = (_ADDR_MAIN, 0x26)
+    INPUT_7 = (_ADDR_MAIN, 0x13)
+    INPUT_8 = (_ADDR_MAIN, 0x91)
+    INPUT_9 = (_ADDR_EXT, 0x90)
+    INPUT_10 = (_ADDR_EXT, 0xA0)
+    INPUT_11 = (_ADDR_EXT, 0xA1)
+    INPUT_12 = (_ADDR_EXT, 0xA2)
+    INPUT_13 = (_ADDR_EXT, 0xA3)
+    INPUT_14 = (_ADDR_EXT, 0xA4)
+    INPUT_15 = (_ADDR_EXT, 0xA5)
+    INPUT_16 = (_ADDR_EXT, 0xA6)
+    INPUT_17 = (_ADDR_EXT, 0xA7)
+    INPUT_18 = (_ADDR_EXT, 0xA8)
+    INPUT_19 = (_ADDR_EXT, 0xA9)
+    INPUT_20 = (_ADDR_EXT, 0xAA)
+    INPUT_21 = (_ADDR_EXT, 0xC6)
+    INPUT_22 = (_ADDR_EXT, 0xC7)
+    INPUT_23 = (_ADDR_EXT, 0xC8)
+    INPUT_24 = (_ADDR_EXT, 0xC9)
+    INPUT_25 = (_ADDR_EXT, 0xCA)
+    INPUT_26 = (_ADDR_EXT, 0xCB)
+    INPUT_27 = (_ADDR_EXT, 0xCC)
+    INPUT_28 = (_ADDR_EXT, 0xCD)
+    INPUT_29 = (_ADDR_EXT, 0xCE)
+    INPUT_30 = (_ADDR_EXT, 0xCF)
+
+    # Zone 2
+    ZONE2_ON = (_ADDR_EXT, 0xD0)
+    ZONE2_STANDBY = (_ADDR_EXT, 0xD1)
+    ZONE2_VOLUME_UP = (_ADDR_EXT, 0xE7)
+    ZONE2_VOLUME_DOWN = (_ADDR_EXT, 0xE8)
+    ZONE2_MUTE = (_ADDR_EXT, 0xE9)
+    ZONE2_INPUT_CYCLE = (_ADDR_EXT, 0x97)
+    ZONE2_PRESET_UP = (_ADDR_EXT, 0xE2)
+    ZONE2_PRESET_DOWN = (_ADDR_EXT, 0xE1)
+    ZONE2_INPUT_1 = (_ADDR_EXT, 0xD2)
+    ZONE2_INPUT_2 = (_ADDR_EXT, 0xD3)
+    ZONE2_INPUT_3 = (_ADDR_EXT, 0xD4)
+    ZONE2_INPUT_4 = (_ADDR_EXT, 0xD5)
+    ZONE2_INPUT_5 = (_ADDR_EXT, 0xD6)
+    ZONE2_INPUT_6 = (_ADDR_EXT, 0xD7)
+    ZONE2_INPUT_7 = (_ADDR_EXT, 0xD8)
+    ZONE2_INPUT_8 = (_ADDR_EXT, 0xD9)
+    ZONE2_INPUT_9 = (_ADDR_EXT, 0xDA)
+    ZONE2_INPUT_10 = (_ADDR_EXT, 0xB0)
+    ZONE2_INPUT_11 = (_ADDR_EXT, 0xB1)
+    ZONE2_INPUT_12 = (_ADDR_EXT, 0xB2)
+    ZONE2_INPUT_13 = (_ADDR_EXT, 0xB3)
+    ZONE2_INPUT_14 = (_ADDR_EXT, 0xB4)
+    ZONE2_INPUT_15 = (_ADDR_EXT, 0xB5)
+    ZONE2_INPUT_16 = (_ADDR_EXT, 0xB6)
+    ZONE2_INPUT_17 = (_ADDR_EXT, 0xB7)
+    ZONE2_INPUT_18 = (_ADDR_EXT, 0xB8)
+    ZONE2_INPUT_19 = (_ADDR_EXT, 0xB9)
+    ZONE2_INPUT_20 = (_ADDR_EXT, 0xBB)
+    ZONE2_INPUT_21 = (_ADDR_EXT, 0xBC)
+    ZONE2_INPUT_22 = (_ADDR_EXT, 0xBD)
+    ZONE2_INPUT_23 = (_ADDR_EXT, 0xBE)
+    ZONE2_INPUT_24 = (_ADDR_EXT, 0xBF)
+    ZONE2_INPUT_25 = (_ADDR_EXT, 0xC0)
+    ZONE2_INPUT_26 = (_ADDR_EXT, 0xC1)
+    ZONE2_INPUT_27 = (_ADDR_EXT, 0xC2)
+    ZONE2_INPUT_28 = (_ADDR_EXT, 0xC3)
+    ZONE2_INPUT_29 = (_ADDR_EXT, 0xC4)
+    ZONE2_INPUT_30 = (_ADDR_EXT, 0xC5)
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build the IR command for this code."""
+        address, command = self.value
+        return NECCommand(
+            address=address,
+            command=command,
+            repeat_count=repeat_count,
+        )

--- a/infrared_protocols/codes/anthem/mrx_x20_x40_avm_x.py
+++ b/infrared_protocols/codes/anthem/mrx_x20_x40_avm_x.py
@@ -11,8 +11,8 @@ This was verified with Anthem Technical Support.
 
 from enum import Enum
 
-from infrared_protocols.commands import Command
-from infrared_protocols.commands.nec import NECCommand
+from ...commands import Command
+from ...commands.nec import NECCommand
 
 _ADDR_MAIN = 0x6A85
 _ADDR_EXT = 0x9A85


### PR DESCRIPTION
Contains IR codes for Anthem MRX x20/x40 and AVM 60/70/90 including 4k and 8k variants.

This was developed using codes supplied by Anthem Technical Support and compatibility was verified with them. 

These codes were tested against a Anthem MRX 1140 4k and Anthem MRX 1140 8k receivers.