### PR TITLE
feat: add LG AC IR protocol encoder and decoder

### DIFF
--- a/infrared_protocols/commands/lg_ac.py
+++ b/infrared_protocols/commands/lg_ac.py
@@ -1,84 +1,118 @@
 """LG air-conditioner IR protocol.
 
-LG 28-bit protocol. Frame layout (28 bits, MSB first):
+LG 28-bit protocol, LG2 timing variant. Frame layout (28 bits, MSB first):
   bits 27-20: 0x88 signature
-  bits 19-16: command upper nibble
-  bits 15-12: command lower nibble
-  bits 11-8:  temperature field (temp_c - 15, valid 0–15)
+  bits 19-16: mode high nibble
+  bits 15-12: mode low nibble
+  bits 11-8:  temperature field (temp_c - 15)
   bits 7-4:   fan speed nibble
-  bits 3-0:   checksum (sum of nibbles 1–6, low 4 bits)
+  bits 3-0:   checksum (sum of nibbles 1-6, low 4 bits)
 
-Power-on/mode-change commands use the LG standard header (8500/4250 µs).
-Power-off uses the LG2 short header (3200/9900 µs) as transmitted by the
-physical remote.
+Bit 3 of the mode's low nibble is a settings-only flag: a remote sets it to change a
+setting on a running unit. Cleared, the same frame also powers the unit on, so this
+encoder always emits it clear.
 """
 
-from dataclasses import dataclass
 from enum import IntEnum
+from typing import Self, override
 
 from . import Command
 
 MIN_TEMP = 16
 MAX_TEMP = 30
 
-_HDR_MARK = 8500
-_HDR_SPACE = 4250
-# Power-off uses a distinct short-burst header captured from the physical remote.
-_OFF_HDR_MARK = 3200
-_OFF_HDR_SPACE = 9900
+_TEMP_OFFSET = 15
+
+_HDR_MARK = 3200
+_HDR_SPACE = 9900
+# Some LG units use this longer header.
+_ALT_HDR_MARK = 8500
+_ALT_HDR_SPACE = 4250
+
 _BIT_MARK = 550
 _BIT_ONE_SPACE = 1600
 _BIT_ZERO_SPACE = 550
 
-_BASE = 0x8800000
+_SIGNATURE = 0x88
+_BASE = _SIGNATURE << 20
 _BITS = 28
 
-# Dry mode always encodes fixed 24 °C regardless of setpoint — verified from captures.
-_DRY_TEMP_FIELD = 0x900
+# Dry mode always encodes fixed 24 °C
+_DRY_TEMP = 24
 
-# Some remotes set bit 3 of the command's low nibble as a variant flag without
-# changing the operating mode; mask it off before mapping back to a mode.
-_CMD_VARIANT_BIT = 0x08
+# Marks a fixed code rather than a state frame. Power-off is one, the display toggle
+# (0x88C00A6) another. They differ only in bits 11-0, which carry no temperature or fan
+# here, so a fixed code is identified by its whole frame.
+_FIXED_CODE_MODE_BYTE = 0xC0
 
-_HDR_TOLERANCE = 2000
+_OFF_FRAME = 0x88C0051
+
+# Masked off when decoding, so a settings frame and a power-on frame give the same mode.
+_SETTINGS_ONLY_BIT = 0x08
+
+# IR receivers distort marks (AGC) but keep spaces accurate, and the space is what tells
+# the two header variants apart.
+_MARK_TOLERANCE = 0.7
+_SPACE_TOLERANCE = 0.25
+
+# A receiver skews a bit's mark and space by roughly a fixed number of microseconds
+# rather than a fixed proportion, so bits get an absolute tolerance. It covers the skew
+# seen in practice and still keeps the zero and one spaces apart (200-900 vs 1250-1950).
+_BIT_TOLERANCE = 350
 
 
 class LgAcMode(IntEnum):
-    """AC operating mode; value is the command byte at frame bits 19-12."""
+    """AC operating mode; value is the mode byte at frame bits 19-12."""
 
     COOL = 0x00
     DRY = 0x01
     FAN_ONLY = 0x02
     HEAT = 0x04
-    OFF = 0xC0
+    OFF = _FIXED_CODE_MODE_BYTE
 
 
 class LgAcFanSpeed(IntEnum):
-    """Fan speed; value is the protocol nibble at frame bits 7-4."""
+    """Fan speed; value is the protocol nibble at frame bits 7-4. Ordered by speed."""
 
-    LOW = 0x0
     QUIET = 0x1
+    LOW = 0x0
+    MEDIUM_LOW = 0x9
     MEDIUM = 0x2
+    MEDIUM_HIGH = 0xA
     HIGH = 0x4
     AUTO = 0x5
 
 
-@dataclass(frozen=True, slots=True)
-class LgAcState:
-    """Decoded AC state from an IR signal."""
-
-    mode: LgAcMode
-    fan: LgAcFanSpeed
-    temp_c: int | None
-
-
 def _checksum(value: int) -> int:
-    total = sum((value >> (i * 4)) & 0xF for i in range(1, 7))
-    return value | (total & 0xF)
+    """Return the checksum nibble: sum of nibbles 1-6, low 4 bits."""
+    return sum((value >> (i * 4)) & 0xF for i in range(1, 7)) & 0xF
 
 
-def _encode_frame(frame: int, hdr_mark: int, hdr_space: int) -> list[int]:
-    timings: list[int] = [hdr_mark, -hdr_space]
+def _is_close(actual: int, expected: int, tolerance: float) -> bool:
+    """Check if a timing is within the given relative tolerance of the expected."""
+    margin = expected * tolerance
+    return expected - margin <= actual <= expected + margin
+
+
+def _matches_header(mark: int, space: int, exp_mark: int, exp_space: int) -> bool:
+    return _is_close(mark, exp_mark, _MARK_TOLERANCE) and _is_close(
+        space, exp_space, _SPACE_TOLERANCE
+    )
+
+
+def _decode_bit(mark: int, space: int) -> int | None:
+    """Decode one bit from its mark and space, or None if it matches neither."""
+    if abs(mark - _BIT_MARK) > _BIT_TOLERANCE:
+        return None
+    if abs(space - _BIT_ZERO_SPACE) <= _BIT_TOLERANCE:
+        return 0
+    if abs(space - _BIT_ONE_SPACE) <= _BIT_TOLERANCE:
+        return 1
+    return None
+
+
+def _encode_frame(frame: int) -> list[int]:
+    timings: list[int] = [_HDR_MARK, -_HDR_SPACE]
     for i in range(_BITS - 1, -1, -1):
         bit = (frame >> i) & 1
         timings.append(_BIT_MARK)
@@ -87,70 +121,16 @@ def _encode_frame(frame: int, hdr_mark: int, hdr_space: int) -> list[int]:
     return timings
 
 
-def decode(timings: list[int]) -> LgAcState | None:
-    """Decode raw LG AC IR timings to an :class:`LgAcState`.
-
-    Returns ``None`` if the signal is not a recognised LG AC command.
-    """
-    if len(timings) < 58:  # header(2) + 28 bit-pairs(56)
-        return None
-
-    hdr_mark = timings[0]
-    hdr_space = abs(timings[1])
-
-    is_standard = (
-        _HDR_MARK - _HDR_TOLERANCE <= hdr_mark <= _HDR_MARK + _HDR_TOLERANCE
-        and _HDR_SPACE - _HDR_TOLERANCE <= hdr_space <= _HDR_SPACE + _HDR_TOLERANCE
-    )
-    is_lg2 = (
-        _OFF_HDR_MARK - _HDR_TOLERANCE <= hdr_mark <= _OFF_HDR_MARK + _HDR_TOLERANCE
-        and _OFF_HDR_SPACE - _HDR_TOLERANCE
-        <= hdr_space
-        <= _OFF_HDR_SPACE + _HDR_TOLERANCE
-    )
-    if not is_standard and not is_lg2:
-        return None
-
-    frame = 0
-    i = 2
-    bits_read = 0
-    while i + 1 < len(timings) and bits_read < _BITS:
-        frame = (frame << 1) | (1 if abs(timings[i + 1]) > 1000 else 0)
-        i += 2
-        bits_read += 1
-
-    if frame >> 20 != 0x88:
-        return None
-
-    nibs = [(frame >> (j * 4)) & 0xF for j in range(7)]
-
-    if sum(nibs[1:7]) & 0xF != nibs[0]:
-        return None
-
-    cmd_byte = ((nibs[4] << 4) | nibs[3]) & ~_CMD_VARIANT_BIT
-    try:
-        mode = LgAcMode(cmd_byte)
-    except ValueError:
-        return None
-
-    try:
-        fan = LgAcFanSpeed(nibs[1])
-    except ValueError:
-        fan = LgAcFanSpeed.AUTO
-    temp_c: int | None = None
-    if mode not in (LgAcMode.OFF, LgAcMode.DRY, LgAcMode.FAN_ONLY) and nibs[2] > 0:
-        temp_c = nibs[2] + 15
-
-    return LgAcState(mode=mode, fan=fan, temp_c=temp_c)
-
-
 class LgAcCommand(Command):
     """LG air-conditioner IR command.
 
-    ``mode=LgAcMode.OFF`` uses the LG2 short header; all other modes use the
-    LG standard header. ``temperature`` is required for ``COOL`` and ``HEAT``
-    modes and is ignored for ``DRY`` (protocol-fixed at 24 °C) and ``FAN_ONLY``.
+    ``temperature`` is required for ``COOL`` and ``HEAT``, and ignored otherwise.
+    ``fan`` is ignored for ``OFF``.
     """
+
+    mode: LgAcMode
+    temperature: int | None
+    fan: LgAcFanSpeed
 
     def __init__(
         self,
@@ -160,7 +140,7 @@ class LgAcCommand(Command):
         fan: LgAcFanSpeed = LgAcFanSpeed.AUTO,
         modulation: int = 38000,
     ) -> None:
-        """Build an LG AC IR command."""
+        """Initialize the LG AC IR command."""
         super().__init__(modulation=modulation)
 
         if mode in (LgAcMode.COOL, LgAcMode.HEAT):
@@ -171,25 +151,86 @@ class LgAcCommand(Command):
                     f"temperature {temperature} out of range {MIN_TEMP}..{MAX_TEMP}"
                 )
 
-        cmd = mode.value << 12
-        fan_bits = fan.value << 4
+        self.mode = mode
+        # Only cool and heat carry a temperature; storing one the frame cannot express
+        # would make a command unequal to itself after a roundtrip.
+        self.temperature = (
+            temperature if mode in (LgAcMode.COOL, LgAcMode.HEAT) else None
+        )
+        self.fan = fan
 
-        if mode is LgAcMode.DRY:
-            temp_field = _DRY_TEMP_FIELD
-        elif mode in (LgAcMode.COOL, LgAcMode.HEAT):
-            temp_field = max(0, min(15, (temperature or MIN_TEMP) - 15)) << 8
-        else:
-            temp_field = 0
-
-        # Power-off is the only mode that uses the LG2 short-burst header.
-        if mode is LgAcMode.OFF:
-            header = (_OFF_HDR_MARK, _OFF_HDR_SPACE)
-        else:
-            header = (_HDR_MARK, _HDR_SPACE)
-
-        frame = _checksum(_BASE | cmd | fan_bits | temp_field)
-        self._timings = _encode_frame(frame, *header)
-
+    @override
     def get_raw_timings(self) -> list[int]:
-        """Return signed µs timings."""
-        return self._timings
+        """Get raw timings for the LG AC command."""
+        if self.mode is LgAcMode.OFF:
+            return _encode_frame(_OFF_FRAME)
+
+        mode_bits = self.mode.value << 12
+        fan_bits = self.fan.value << 4
+
+        if self.mode is LgAcMode.DRY:
+            temp_bits = (_DRY_TEMP - _TEMP_OFFSET) << 8
+        elif self.temperature is not None:
+            temp_bits = (self.temperature - _TEMP_OFFSET) << 8
+        else:
+            temp_bits = 0
+
+        frame_data = _BASE | mode_bits | fan_bits | temp_bits
+        return _encode_frame(frame_data | _checksum(frame_data))
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into an LgAcCommand.
+
+        Returns an LgAcCommand if the timings match, or None otherwise.
+        """
+        # Header pair (2) + 28 bit pairs (56) + the trailing mark (1)
+        if len(timings) < 2 + 2 * _BITS + 1:
+            return None
+
+        hdr_mark = timings[0]
+        hdr_space = abs(timings[1])
+        if not (
+            _matches_header(hdr_mark, hdr_space, _HDR_MARK, _HDR_SPACE)
+            or _matches_header(hdr_mark, hdr_space, _ALT_HDR_MARK, _ALT_HDR_SPACE)
+        ):
+            return None
+
+        frame = 0
+        for i in range(2, 2 + 2 * _BITS, 2):
+            bit = _decode_bit(timings[i], abs(timings[i + 1]))
+            if bit is None:
+                return None
+            frame = (frame << 1) | bit
+
+        if abs(timings[2 + 2 * _BITS] - _BIT_MARK) > _BIT_TOLERANCE:
+            return None
+
+        if frame >> 20 != _SIGNATURE:
+            return None
+
+        if _checksum(frame) != frame & 0xF:
+            return None
+
+        if frame == _OFF_FRAME:
+            return cls(mode=LgAcMode.OFF)
+
+        mode_byte = ((frame >> 12) & 0xFF) & ~_SETTINGS_ONLY_BIT
+        if mode_byte == _FIXED_CODE_MODE_BYTE:
+            # A fixed code this class does not model, such as the display toggle. The
+            # power-off code is the one exception, matched in full above.
+            return None
+
+        try:
+            mode = LgAcMode(mode_byte)
+            fan = LgAcFanSpeed((frame >> 4) & 0xF)
+        except ValueError:
+            return None
+
+        temperature: int | None = None
+        if mode in (LgAcMode.COOL, LgAcMode.HEAT):
+            temperature = ((frame >> 8) & 0xF) + _TEMP_OFFSET
+            if not MIN_TEMP <= temperature <= MAX_TEMP:
+                return None
+
+        return cls(mode=mode, temperature=temperature, fan=fan)

--- a/infrared_protocols/commands/lg_ac.py
+++ b/infrared_protocols/commands/lg_ac.py
@@ -33,36 +33,34 @@ _BIT_ZERO_SPACE = 550
 _BASE = 0x8800000
 _BITS = 28
 
-_CMD_ON_COOL = 0x00000
-_CMD_ON_DRY = 0x01000
-_CMD_ON_FAN = 0x02000
-_CMD_ON_HEAT = 0x04000
-_CMD_OFF = 0xC0000
-
 # Dry mode always encodes fixed 24 °C regardless of setpoint — verified from captures.
 _DRY_TEMP_FIELD = 0x900
+
+# Some remotes set bit 3 of the command's low nibble as a variant flag without
+# changing the operating mode; mask it off before mapping back to a mode.
+_CMD_VARIANT_BIT = 0x08
 
 _HDR_TOLERANCE = 2000
 
 
 class LgAcMode(IntEnum):
-    """AC operating mode."""
+    """AC operating mode; value is the command byte at frame bits 19-12."""
 
-    OFF = 0
-    COOL = 1
-    DRY = 2
-    FAN_ONLY = 3
-    HEAT = 4
+    COOL = 0x00
+    DRY = 0x01
+    FAN_ONLY = 0x02
+    HEAT = 0x04
+    OFF = 0xC0
 
 
 class LgAcFanSpeed(IntEnum):
-    """Fan speed."""
+    """Fan speed; value is the protocol nibble at frame bits 7-4."""
 
-    AUTO = 0
-    QUIET = 1
-    LOW = 2
-    MEDIUM = 3
-    HIGH = 4
+    LOW = 0x0
+    QUIET = 0x1
+    MEDIUM = 0x2
+    HIGH = 0x4
+    AUTO = 0x5
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,36 +70,6 @@ class LgAcState:
     mode: LgAcMode
     fan: LgAcFanSpeed
     temp_c: int | None
-
-
-_MODE_TO_CMD: dict[LgAcMode, int] = {
-    LgAcMode.COOL: _CMD_ON_COOL,
-    LgAcMode.DRY: _CMD_ON_DRY,
-    LgAcMode.FAN_ONLY: _CMD_ON_FAN,
-    LgAcMode.HEAT: _CMD_ON_HEAT,
-}
-
-_FAN_TO_BITS: dict[LgAcFanSpeed, int] = {
-    LgAcFanSpeed.AUTO: 0x50,
-    LgAcFanSpeed.QUIET: 0x10,
-    LgAcFanSpeed.LOW: 0x00,
-    LgAcFanSpeed.MEDIUM: 0x20,
-    LgAcFanSpeed.HIGH: 0x40,
-}
-_FAN_BITS_TO_SPEED: dict[int, LgAcFanSpeed] = {v: k for k, v in _FAN_TO_BITS.items()}
-
-# Decode: (nibble4, nibble3) → LgAcMode
-_CMD_NIBS_TO_MODE: dict[tuple[int, int], LgAcMode] = {
-    (0, 0x0): LgAcMode.COOL,
-    (0, 0x8): LgAcMode.COOL,
-    (0, 0x1): LgAcMode.DRY,
-    (0, 0x9): LgAcMode.DRY,
-    (0, 0x2): LgAcMode.FAN_ONLY,
-    (0, 0xA): LgAcMode.FAN_ONLY,
-    (0, 0x4): LgAcMode.HEAT,
-    (0, 0xC): LgAcMode.HEAT,
-    (0xC, 0x0): LgAcMode.OFF,
-}
 
 
 def _checksum(value: int) -> int:
@@ -159,11 +127,16 @@ def decode(timings: list[int]) -> LgAcState | None:
     if sum(nibs[1:7]) & 0xF != nibs[0]:
         return None
 
-    mode = _CMD_NIBS_TO_MODE.get((nibs[4], nibs[3]))
-    if mode is None:
+    cmd_byte = ((nibs[4] << 4) | nibs[3]) & ~_CMD_VARIANT_BIT
+    try:
+        mode = LgAcMode(cmd_byte)
+    except ValueError:
         return None
 
-    fan = _FAN_BITS_TO_SPEED.get(nibs[1] << 4, LgAcFanSpeed.AUTO)
+    try:
+        fan = LgAcFanSpeed(nibs[1])
+    except ValueError:
+        fan = LgAcFanSpeed.AUTO
     temp_c: int | None = None
     if mode not in (LgAcMode.OFF, LgAcMode.DRY, LgAcMode.FAN_ONLY) and nibs[2] > 0:
         temp_c = nibs[2] + 15
@@ -198,22 +171,24 @@ class LgAcCommand(Command):
                     f"temperature {temperature} out of range {MIN_TEMP}..{MAX_TEMP}"
                 )
 
-        fan_bits = _FAN_TO_BITS[fan]
+        cmd = mode.value << 12
+        fan_bits = fan.value << 4
 
-        if mode is LgAcMode.OFF:
-            frame = _checksum(_BASE | _CMD_OFF | fan_bits)
-            self._timings = _encode_frame(frame, _OFF_HDR_MARK, _OFF_HDR_SPACE)
-        elif mode is LgAcMode.DRY:
-            frame = _checksum(_BASE | _CMD_ON_DRY | fan_bits | _DRY_TEMP_FIELD)
-            self._timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
-        elif mode is LgAcMode.FAN_ONLY:
-            frame = _checksum(_BASE | _CMD_ON_FAN | fan_bits)
-            self._timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
-        else:
-            cmd = _MODE_TO_CMD[mode]
+        if mode is LgAcMode.DRY:
+            temp_field = _DRY_TEMP_FIELD
+        elif mode in (LgAcMode.COOL, LgAcMode.HEAT):
             temp_field = max(0, min(15, (temperature or MIN_TEMP) - 15)) << 8
-            frame = _checksum(_BASE | cmd | fan_bits | temp_field)
-            self._timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
+        else:
+            temp_field = 0
+
+        # Power-off is the only mode that uses the LG2 short-burst header.
+        if mode is LgAcMode.OFF:
+            header = (_OFF_HDR_MARK, _OFF_HDR_SPACE)
+        else:
+            header = (_HDR_MARK, _HDR_SPACE)
+
+        frame = _checksum(_BASE | cmd | fan_bits | temp_field)
+        self._timings = _encode_frame(frame, *header)
 
     def get_raw_timings(self) -> list[int]:
         """Return signed µs timings."""

--- a/infrared_protocols/commands/lg_ac.py
+++ b/infrared_protocols/commands/lg_ac.py
@@ -1,0 +1,220 @@
+"""LG air-conditioner IR protocol.
+
+LG 28-bit protocol. Frame layout (28 bits, MSB first):
+  bits 27-20: 0x88 signature
+  bits 19-16: command upper nibble
+  bits 15-12: command lower nibble
+  bits 11-8:  temperature field (temp_c - 15, valid 0–15)
+  bits 7-4:   fan speed nibble
+  bits 3-0:   checksum (sum of nibbles 1–6, low 4 bits)
+
+Power-on/mode-change commands use the LG standard header (8500/4250 µs).
+Power-off uses the LG2 short header (3200/9900 µs) as transmitted by the
+physical remote.
+"""
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+from . import Command
+
+MIN_TEMP = 16
+MAX_TEMP = 30
+
+_HDR_MARK = 8500
+_HDR_SPACE = 4250
+# Power-off uses a distinct short-burst header captured from the physical remote.
+_OFF_HDR_MARK = 3200
+_OFF_HDR_SPACE = 9900
+_BIT_MARK = 550
+_BIT_ONE_SPACE = 1600
+_BIT_ZERO_SPACE = 550
+
+_BASE = 0x8800000
+_BITS = 28
+
+_CMD_ON_COOL = 0x00000
+_CMD_ON_DRY = 0x01000
+_CMD_ON_FAN = 0x02000
+_CMD_ON_HEAT = 0x04000
+_CMD_OFF = 0xC0000
+
+# Dry mode always encodes fixed 24 °C regardless of setpoint — verified from captures.
+_DRY_TEMP_FIELD = 0x900
+
+_HDR_TOLERANCE = 2000
+
+
+class LgAcMode(IntEnum):
+    """AC operating mode."""
+
+    OFF = 0
+    COOL = 1
+    DRY = 2
+    FAN_ONLY = 3
+    HEAT = 4
+
+
+class LgAcFanSpeed(IntEnum):
+    """Fan speed."""
+
+    AUTO = 0
+    QUIET = 1
+    LOW = 2
+    MEDIUM = 3
+    HIGH = 4
+
+
+@dataclass(frozen=True, slots=True)
+class LgAcState:
+    """Decoded AC state from an IR signal."""
+
+    mode: LgAcMode
+    fan: LgAcFanSpeed
+    temp_c: int | None
+
+
+_MODE_TO_CMD: dict[LgAcMode, int] = {
+    LgAcMode.COOL: _CMD_ON_COOL,
+    LgAcMode.DRY: _CMD_ON_DRY,
+    LgAcMode.FAN_ONLY: _CMD_ON_FAN,
+    LgAcMode.HEAT: _CMD_ON_HEAT,
+}
+
+_FAN_TO_BITS: dict[LgAcFanSpeed, int] = {
+    LgAcFanSpeed.AUTO: 0x50,
+    LgAcFanSpeed.QUIET: 0x10,
+    LgAcFanSpeed.LOW: 0x00,
+    LgAcFanSpeed.MEDIUM: 0x20,
+    LgAcFanSpeed.HIGH: 0x40,
+}
+_FAN_BITS_TO_SPEED: dict[int, LgAcFanSpeed] = {v: k for k, v in _FAN_TO_BITS.items()}
+
+# Decode: (nibble4, nibble3) → LgAcMode
+_CMD_NIBS_TO_MODE: dict[tuple[int, int], LgAcMode] = {
+    (0, 0x0): LgAcMode.COOL,
+    (0, 0x8): LgAcMode.COOL,
+    (0, 0x1): LgAcMode.DRY,
+    (0, 0x9): LgAcMode.DRY,
+    (0, 0x2): LgAcMode.FAN_ONLY,
+    (0, 0xA): LgAcMode.FAN_ONLY,
+    (0, 0x4): LgAcMode.HEAT,
+    (0, 0xC): LgAcMode.HEAT,
+    (0xC, 0x0): LgAcMode.OFF,
+}
+
+
+def _checksum(value: int) -> int:
+    total = sum((value >> (i * 4)) & 0xF for i in range(1, 7))
+    return value | (total & 0xF)
+
+
+def _encode_frame(frame: int, hdr_mark: int, hdr_space: int) -> list[int]:
+    timings: list[int] = [hdr_mark, -hdr_space]
+    for i in range(_BITS - 1, -1, -1):
+        bit = (frame >> i) & 1
+        timings.append(_BIT_MARK)
+        timings.append(-(_BIT_ONE_SPACE if bit else _BIT_ZERO_SPACE))
+    timings.append(_BIT_MARK)
+    return timings
+
+
+def decode(timings: list[int]) -> LgAcState | None:
+    """Decode raw LG AC IR timings to an :class:`LgAcState`.
+
+    Returns ``None`` if the signal is not a recognised LG AC command.
+    """
+    if len(timings) < 58:  # header(2) + 28 bit-pairs(56)
+        return None
+
+    hdr_mark = timings[0]
+    hdr_space = abs(timings[1])
+
+    is_standard = (
+        _HDR_MARK - _HDR_TOLERANCE <= hdr_mark <= _HDR_MARK + _HDR_TOLERANCE
+        and _HDR_SPACE - _HDR_TOLERANCE <= hdr_space <= _HDR_SPACE + _HDR_TOLERANCE
+    )
+    is_lg2 = (
+        _OFF_HDR_MARK - _HDR_TOLERANCE <= hdr_mark <= _OFF_HDR_MARK + _HDR_TOLERANCE
+        and _OFF_HDR_SPACE - _HDR_TOLERANCE
+        <= hdr_space
+        <= _OFF_HDR_SPACE + _HDR_TOLERANCE
+    )
+    if not is_standard and not is_lg2:
+        return None
+
+    frame = 0
+    i = 2
+    bits_read = 0
+    while i + 1 < len(timings) and bits_read < _BITS:
+        frame = (frame << 1) | (1 if abs(timings[i + 1]) > 1000 else 0)
+        i += 2
+        bits_read += 1
+
+    if frame >> 20 != 0x88:
+        return None
+
+    nibs = [(frame >> (j * 4)) & 0xF for j in range(7)]
+
+    if sum(nibs[1:7]) & 0xF != nibs[0]:
+        return None
+
+    mode = _CMD_NIBS_TO_MODE.get((nibs[4], nibs[3]))
+    if mode is None:
+        return None
+
+    fan = _FAN_BITS_TO_SPEED.get(nibs[1] << 4, LgAcFanSpeed.AUTO)
+    temp_c: int | None = None
+    if mode not in (LgAcMode.OFF, LgAcMode.DRY, LgAcMode.FAN_ONLY) and nibs[2] > 0:
+        temp_c = nibs[2] + 15
+
+    return LgAcState(mode=mode, fan=fan, temp_c=temp_c)
+
+
+class LgAcCommand(Command):
+    """LG air-conditioner IR command.
+
+    ``mode=LgAcMode.OFF`` uses the LG2 short header; all other modes use the
+    LG standard header. ``temperature`` is required for ``COOL`` and ``HEAT``
+    modes and is ignored for ``DRY`` (protocol-fixed at 24 °C) and ``FAN_ONLY``.
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: LgAcMode,
+        temperature: int | None = None,
+        fan: LgAcFanSpeed = LgAcFanSpeed.AUTO,
+        modulation: int = 38000,
+    ) -> None:
+        """Build an LG AC IR command."""
+        super().__init__(modulation=modulation)
+
+        if mode in (LgAcMode.COOL, LgAcMode.HEAT):
+            if temperature is None:
+                raise ValueError(f"temperature is required for mode {mode.name}")
+            if not MIN_TEMP <= temperature <= MAX_TEMP:
+                raise ValueError(
+                    f"temperature {temperature} out of range {MIN_TEMP}..{MAX_TEMP}"
+                )
+
+        fan_bits = _FAN_TO_BITS[fan]
+
+        if mode is LgAcMode.OFF:
+            frame = _checksum(_BASE | _CMD_OFF | fan_bits)
+            self._timings = _encode_frame(frame, _OFF_HDR_MARK, _OFF_HDR_SPACE)
+        elif mode is LgAcMode.DRY:
+            frame = _checksum(_BASE | _CMD_ON_DRY | fan_bits | _DRY_TEMP_FIELD)
+            self._timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
+        elif mode is LgAcMode.FAN_ONLY:
+            frame = _checksum(_BASE | _CMD_ON_FAN | fan_bits)
+            self._timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
+        else:
+            cmd = _MODE_TO_CMD[mode]
+            temp_field = max(0, min(15, (temperature or MIN_TEMP) - 15)) << 8
+            frame = _checksum(_BASE | cmd | fan_bits | temp_field)
+            self._timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
+
+    def get_raw_timings(self) -> list[int]:
+        """Return signed µs timings."""
+        return self._timings

--- a/infrared_protocols/commands/lg_ac.py
+++ b/infrared_protocols/commands/lg_ac.py
@@ -72,7 +72,7 @@ class LgAcMode(IntEnum):
 
 
 class LgAcFanSpeed(IntEnum):
-    """Fan speed; value is the protocol nibble at frame bits 7-4. Ordered by speed."""
+    """Fan speed; value is the protocol nibble at frame bits 7-4."""
 
     QUIET = 0x1
     LOW = 0x0
@@ -130,7 +130,7 @@ class LgAcCommand(Command):
 
     mode: LgAcMode
     temperature: int | None
-    fan: LgAcFanSpeed
+    fan: LgAcFanSpeed | None
 
     def __init__(
         self,
@@ -157,7 +157,9 @@ class LgAcCommand(Command):
         self.temperature = (
             temperature if mode in (LgAcMode.COOL, LgAcMode.HEAT) else None
         )
-        self.fan = fan
+        # OFF is a fixed frame that carries no fan; like temperature it is dropped to
+        # None, so the field never claims a fan the frame does not send.
+        self.fan = None if mode is LgAcMode.OFF else fan
 
     @override
     def get_raw_timings(self) -> list[int]:
@@ -165,6 +167,7 @@ class LgAcCommand(Command):
         if self.mode is LgAcMode.OFF:
             return _encode_frame(_OFF_FRAME)
 
+        assert self.fan is not None, "fan missing for non-OFF mode"
         mode_bits = self.mode.value << 12
         fan_bits = self.fan.value << 4
 

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -205,7 +205,31 @@ def test_decode_returns_none_for_bad_checksum() -> None:
 
 def test_decode_returns_none_for_unknown_mode() -> None:
     """decode must return None when mode nibbles have no mapping."""
-    # (nibs[4], nibs[3]) = (0xF, 0xF) is not in _CMD_NIBS_TO_MODE
+    # (nibs[4], nibs[3]) = (0xF, 0xF) maps to no known mode
     frame = _checksum(0x88FF000)
     timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
     assert decode(timings) is None
+
+
+# ── Decoder: command-nibble variant bit (bit 3 of nibble 3) ───────────────────
+
+
+@pytest.mark.parametrize(
+    ("nibble3", "expected_mode"),
+    [
+        pytest.param(0x8, LgAcMode.COOL, id="cool_variant"),
+        pytest.param(0x9, LgAcMode.DRY, id="dry_variant"),
+        pytest.param(0xA, LgAcMode.FAN_ONLY, id="fan_only_variant"),
+        pytest.param(0xC, LgAcMode.HEAT, id="heat_variant"),
+    ],
+)
+def test_decode_command_nibble_variant_bit(
+    nibble3: int, expected_mode: LgAcMode
+) -> None:
+    """Bit 3 set in command nibble 3 must decode to the same base mode."""
+    # nibble4 = 0, nibble3 = variant; temp/fan nibbles zero
+    frame = _checksum(0x8800000 | (nibble3 << 12))
+    timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
+    result = decode(timings)
+    assert result is not None
+    assert result.mode == expected_mode

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -1,80 +1,138 @@
-"""Tests for the LG air-conditioner IR command and decoder."""
+"""Tests for the LG air-conditioner IR command."""
 
 import pytest
 
 from infrared_protocols.commands.lg_ac import (
+    _BIT_MARK,
+    _BIT_ONE_SPACE,
+    _BIT_ZERO_SPACE,
+    _BITS,
     LgAcCommand,
     LgAcFanSpeed,
     LgAcMode,
-    LgAcState,
-    MIN_TEMP,
-    _OFF_HDR_MARK,
-    _OFF_HDR_SPACE,
-    _HDR_MARK,
-    _HDR_SPACE,
-    _checksum,
-    _encode_frame,
-    decode,
 )
 
+_HDR = (3200, 9900)
+_ALT_HDR = (8500, 4250)
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# Power-on frames: settings bit clear. The encoder emits these.
+_COOL_26_MEDIUM = 0x8800B2D
+_COOL_24_MEDIUM_LOW = 0x8800992
+_COOL_24_MEDIUM_HIGH = 0x88009A3
+_OFF = 0x88C0051
+
+# Settings frames: settings bit set. Decode-only.
+_SET_COOL_24_AUTO = 0x8808956
+_SET_COOL_16_MEDIUM_HIGH = 0x88081A3
+_SET_COOL_30_MEDIUM_HIGH = 0x8808FA1
+_SET_DRY_24_LOW = 0x8809902
+_SET_FAN_ONLY_24_HIGH = 0x880A947
+
+
+_ONE_THRESHOLD = (_BIT_ONE_SPACE + _BIT_ZERO_SPACE) // 2
 
 
 def _extract_frame(timings: list[int]) -> int:
-    """Extract the 28-bit frame integer from raw timings."""
+    """Extract the frame integer from raw timings, one bit per mark/space pair."""
     frame = 0
-    i = 2
-    bits_read = 0
-    while i + 1 < len(timings) and bits_read < 28:
-        frame = (frame << 1) | (1 if abs(timings[i + 1]) > 1000 else 0)
-        i += 2
-        bits_read += 1
+    for i in range(2, 2 + 2 * _BITS, 2):
+        frame = (frame << 1) | (1 if abs(timings[i + 1]) > _ONE_THRESHOLD else 0)
     return frame
 
 
-# ── Encoder: known-good frame values (verified against hardware captures) ────
+def _build_timings(frame: int, header: tuple[int, int] = _HDR) -> list[int]:
+    """Build raw timings for a frame without going through the encoder."""
+    timings = [header[0], -header[1]]
+    for i in reversed(range(_BITS)):
+        one = (frame >> i) & 1
+        timings += [_BIT_MARK, -(_BIT_ONE_SPACE if one else _BIT_ZERO_SPACE)]
+    timings.append(_BIT_MARK)
+    return timings
 
 
-def test_encode_off_frame() -> None:
-    """Power-off must produce frame 0x88C0051 with LG2-short header."""
-    cmd = LgAcCommand(mode=LgAcMode.OFF)
-    timings = cmd.get_raw_timings()
-    assert timings[0] == _OFF_HDR_MARK
-    assert abs(timings[1]) == _OFF_HDR_SPACE
-    assert _extract_frame(timings) == 0x88C0051
+def test_encode_timing_values() -> None:
+    """Pin the physical layer: LG2 header, bit mark, and the two bit spaces."""
+    timings = LgAcCommand(mode=LgAcMode.COOL, temperature=24).get_raw_timings()
 
-
-def test_encode_cool_24_auto_frame() -> None:
-    """Cool 24 °C / auto fan must produce frame 0x880095E."""
-    cmd = LgAcCommand(mode=LgAcMode.COOL, temperature=24, fan=LgAcFanSpeed.AUTO)
-    assert cmd.get_raw_timings()[0] == _HDR_MARK
-    assert _extract_frame(cmd.get_raw_timings()) == 0x880095E
-
-
-def test_encode_dry_auto_frame() -> None:
-    """Dry / auto fan must produce frame 0x880195F."""
-    cmd = LgAcCommand(mode=LgAcMode.DRY, fan=LgAcFanSpeed.AUTO)
-    assert _extract_frame(cmd.get_raw_timings()) == 0x880195F
+    assert timings[:2] == [3200, -9900]
+    assert len(timings) == 2 + 2 * 28 + 1
+    assert all(mark == 550 for mark in timings[2::2])
+    assert {abs(space) for space in timings[3::2]} == {550, 1600}
 
 
 @pytest.mark.parametrize(
-    ("temp", "fan", "expected_hex"),
+    ("mode", "temperature", "fan", "expected_frame"),
     [
-        pytest.param(18, LgAcFanSpeed.AUTO, 0x8800358, id="18_auto"),
-        pytest.param(30, LgAcFanSpeed.AUTO, 0x8800F54, id="30_auto"),
-        pytest.param(24, LgAcFanSpeed.LOW, 0x8800909, id="24_low"),
-        pytest.param(24, LgAcFanSpeed.MEDIUM, 0x880092B, id="24_medium"),
-        pytest.param(24, LgAcFanSpeed.HIGH, 0x880094D, id="24_high"),
+        pytest.param(
+            LgAcMode.COOL,
+            26,
+            LgAcFanSpeed.MEDIUM,
+            _COOL_26_MEDIUM,
+            id="cool_26_medium",
+        ),
+        pytest.param(
+            LgAcMode.COOL,
+            24,
+            LgAcFanSpeed.MEDIUM_LOW,
+            _COOL_24_MEDIUM_LOW,
+            id="cool_24_medium_low",
+        ),
+        pytest.param(
+            LgAcMode.COOL,
+            24,
+            LgAcFanSpeed.MEDIUM_HIGH,
+            _COOL_24_MEDIUM_HIGH,
+            id="cool_24_medium_high",
+        ),
+        pytest.param(LgAcMode.OFF, None, LgAcFanSpeed.AUTO, _OFF, id="off"),
     ],
 )
-def test_encode_cool_frames(temp: int, fan: LgAcFanSpeed, expected_hex: int) -> None:
-    """Verify cool encoder against known-good frames."""
-    cmd = LgAcCommand(mode=LgAcMode.COOL, temperature=temp, fan=fan)
-    assert _extract_frame(cmd.get_raw_timings()) == expected_hex
+def test_encode_matches_captured_frame(
+    mode: LgAcMode,
+    temperature: int | None,
+    fan: LgAcFanSpeed,
+    expected_frame: int,
+) -> None:
+    """Encoder output must equal the frame the remote sends."""
+    cmd = LgAcCommand(mode=mode, temperature=temperature, fan=fan)
+    assert _extract_frame(cmd.get_raw_timings()) == expected_frame
 
 
-# ── Encoder: modulation and repeat defaults ───────────────────────────────────
+@pytest.mark.parametrize(
+    "fan",
+    [
+        pytest.param(LgAcFanSpeed.LOW, id="low"),
+        pytest.param(LgAcFanSpeed.HIGH, id="high"),
+        pytest.param(LgAcFanSpeed.MEDIUM_HIGH, id="medium_high"),
+    ],
+)
+def test_encode_off_ignores_fan(fan: LgAcFanSpeed) -> None:
+    """Power-off is a fixed frame; the fan argument must not reach it."""
+    cmd = LgAcCommand(mode=LgAcMode.OFF, fan=fan)
+    assert _extract_frame(cmd.get_raw_timings()) == _OFF
+
+
+def test_encode_dry_pins_temperature() -> None:
+    """Dry encodes 24 °C whatever the caller asks for."""
+    dry = LgAcCommand(mode=LgAcMode.DRY, temperature=20, fan=LgAcFanSpeed.LOW)
+    cool_24 = LgAcCommand(mode=LgAcMode.COOL, temperature=24, fan=LgAcFanSpeed.LOW)
+
+    dry_temp_nibble = (_extract_frame(dry.get_raw_timings()) >> 8) & 0xF
+    cool_temp_nibble = (_extract_frame(cool_24.get_raw_timings()) >> 8) & 0xF
+    assert dry_temp_nibble == cool_temp_nibble
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param(LgAcMode.OFF, id="off"),
+        pytest.param(LgAcMode.DRY, id="dry"),
+        pytest.param(LgAcMode.FAN_ONLY, id="fan_only"),
+    ],
+)
+def test_temperature_dropped_for_modes_that_ignore_it(mode: LgAcMode) -> None:
+    """A temperature the frame cannot carry must not be stored."""
+    assert LgAcCommand(mode=mode, temperature=25).temperature is None
 
 
 def test_default_modulation() -> None:
@@ -82,9 +140,6 @@ def test_default_modulation() -> None:
     cmd = LgAcCommand(mode=LgAcMode.OFF)
     assert cmd.modulation == 38000
     assert cmd.repeat_count == 0
-
-
-# ── Encoder: validation ───────────────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -115,121 +170,137 @@ def test_temperature_out_of_range(temp: int, mode: LgAcMode) -> None:
         LgAcCommand(mode=mode, temperature=temp)
 
 
-# ── Decoder: roundtrips ───────────────────────────────────────────────────────
-
-
-def test_decode_roundtrip_cool() -> None:
-    """Decoded cool frame must reconstruct mode, fan, and temperature."""
-    cmd = LgAcCommand(mode=LgAcMode.COOL, temperature=22, fan=LgAcFanSpeed.HIGH)
-    result = decode(cmd.get_raw_timings())
-    assert result == LgAcState(mode=LgAcMode.COOL, fan=LgAcFanSpeed.HIGH, temp_c=22)
-
-
-def test_decode_roundtrip_off() -> None:
-    """Decoded off frame must return LgAcMode.OFF."""
-    result = decode(LgAcCommand(mode=LgAcMode.OFF).get_raw_timings())
+@pytest.mark.parametrize(
+    ("frame", "mode", "temperature", "fan"),
+    [
+        pytest.param(
+            _SET_COOL_24_AUTO, LgAcMode.COOL, 24, LgAcFanSpeed.AUTO, id="cool_24_auto"
+        ),
+        pytest.param(
+            _SET_COOL_16_MEDIUM_HIGH,
+            LgAcMode.COOL,
+            16,
+            LgAcFanSpeed.MEDIUM_HIGH,
+            id="cool_16_medium_high",
+        ),
+        pytest.param(
+            _SET_COOL_30_MEDIUM_HIGH,
+            LgAcMode.COOL,
+            30,
+            LgAcFanSpeed.MEDIUM_HIGH,
+            id="cool_30_medium_high",
+        ),
+        pytest.param(
+            _SET_DRY_24_LOW, LgAcMode.DRY, None, LgAcFanSpeed.LOW, id="dry_low"
+        ),
+        pytest.param(
+            _SET_FAN_ONLY_24_HIGH,
+            LgAcMode.FAN_ONLY,
+            None,
+            LgAcFanSpeed.HIGH,
+            id="fan_only_high",
+        ),
+        pytest.param(_OFF, LgAcMode.OFF, None, LgAcFanSpeed.AUTO, id="off"),
+        pytest.param(
+            _COOL_26_MEDIUM, LgAcMode.COOL, 26, LgAcFanSpeed.MEDIUM, id="cool_26_medium"
+        ),
+    ],
+)
+def test_decode_captured_frame(
+    frame: int, mode: LgAcMode, temperature: int | None, fan: LgAcFanSpeed
+) -> None:
+    """Settings frames and power-on frames must decode to the same state."""
+    result = LgAcCommand.from_raw_timings(_build_timings(frame))
     assert result is not None
-    assert result.mode == LgAcMode.OFF
-
-
-def test_decode_roundtrip_dry() -> None:
-    """Decoded dry frame must return DRY mode with correct fan."""
-    result = decode(LgAcCommand(mode=LgAcMode.DRY, fan=LgAcFanSpeed.LOW).get_raw_timings())
-    assert result is not None
-    assert result.mode == LgAcMode.DRY
-    assert result.fan == LgAcFanSpeed.LOW
-
-
-def test_decode_roundtrip_heat() -> None:
-    """Decoded heat frame must reconstruct mode, fan, and temperature."""
-    result = decode(
-        LgAcCommand(mode=LgAcMode.HEAT, temperature=26, fan=LgAcFanSpeed.MEDIUM).get_raw_timings()
-    )
-    assert result == LgAcState(mode=LgAcMode.HEAT, fan=LgAcFanSpeed.MEDIUM, temp_c=26)
-
-
-def test_decode_roundtrip_fan_only() -> None:
-    """Decoded fan-only frame must return FAN_ONLY with correct fan speed."""
-    result = decode(LgAcCommand(mode=LgAcMode.FAN_ONLY, fan=LgAcFanSpeed.HIGH).get_raw_timings())
-    assert result is not None
-    assert result.mode == LgAcMode.FAN_ONLY
-    assert result.fan == LgAcFanSpeed.HIGH
+    assert result.mode == mode
+    assert result.temperature == temperature
+    assert result.fan == fan
 
 
 @pytest.mark.parametrize(
-    ("mode", "temp", "fan"),
+    ("mode", "temperature", "fan"),
     [
-        pytest.param(LgAcMode.COOL, 24, LgAcFanSpeed.AUTO, id="cool_24_auto"),
-        pytest.param(LgAcMode.COOL, 18, LgAcFanSpeed.LOW, id="cool_18_low"),
-        pytest.param(LgAcMode.COOL, 30, LgAcFanSpeed.HIGH, id="cool_30_high"),
-        pytest.param(LgAcMode.HEAT, 20, LgAcFanSpeed.MEDIUM, id="heat_20_medium"),
-        pytest.param(LgAcMode.HEAT, 28, LgAcFanSpeed.QUIET, id="heat_28_quiet"),
+        pytest.param(LgAcMode.COOL, 22, LgAcFanSpeed.QUIET, id="cool_22_quiet"),
+        pytest.param(LgAcMode.HEAT, 26, LgAcFanSpeed.MEDIUM, id="heat_26_medium"),
+        pytest.param(LgAcMode.HEAT, 20, LgAcFanSpeed.LOW, id="heat_20_low"),
+        pytest.param(LgAcMode.FAN_ONLY, None, LgAcFanSpeed.AUTO, id="fan_only_auto"),
     ],
 )
-def test_decode_roundtrip_parametrized(
-    mode: LgAcMode, temp: int, fan: LgAcFanSpeed
-) -> None:
-    """Roundtrip encode→decode must preserve mode, fan, and temperature."""
-    cmd = LgAcCommand(mode=mode, temperature=temp, fan=fan)
-    result = decode(cmd.get_raw_timings())
-    assert result == LgAcState(mode=mode, fan=fan, temp_c=temp)
+def test_roundtrip(mode: LgAcMode, temperature: int | None, fan: LgAcFanSpeed) -> None:
+    """Roundtrip encode-decode must preserve mode, fan, and temperature."""
+    cmd = LgAcCommand(mode=mode, temperature=temperature, fan=fan)
+    result = LgAcCommand.from_raw_timings(cmd.get_raw_timings())
+    assert result is not None
+    assert result.mode == mode
+    assert result.temperature == temperature
+    assert result.fan == fan
 
 
-# ── Decoder: rejection cases ──────────────────────────────────────────────────
+def test_decode_accepts_stretched_header_mark() -> None:
+    """Receivers stretch marks; a 3200 µs header mark can arrive as 5121 µs."""
+    result = LgAcCommand.from_raw_timings(
+        _build_timings(_SET_COOL_24_AUTO, (5121, 9900))
+    )
+    assert result is not None
+    assert result.mode == LgAcMode.COOL
+
+
+def test_decode_accepts_alternate_header() -> None:
+    """Some LG units use the longer 8500/4250 header with an identical payload."""
+    result = LgAcCommand.from_raw_timings(_build_timings(_SET_COOL_24_AUTO, _ALT_HDR))
+    assert result is not None
+    assert result.mode == LgAcMode.COOL
+    assert result.temperature == 24
 
 
 def test_decode_returns_none_for_short_timings() -> None:
-    """decode must return None for incomplete signals."""
-    assert decode([500, -400]) is None
+    """from_raw_timings must return None for incomplete signals."""
+    assert LgAcCommand.from_raw_timings([500, -400]) is None
 
 
-def test_decode_returns_none_for_non_lg_ac() -> None:
-    """decode must return None for frames with wrong signature."""
-    # NEC-style header (9000/4500) with wrong signature
-    junk = [9000, -4500] + [550, -1600] * 32
-    assert decode(junk) is None
+def test_decode_returns_none_without_trailing_mark() -> None:
+    """A frame truncated before its trailing mark must not decode as valid."""
+    timings = _build_timings(_SET_COOL_24_AUTO)
+    assert LgAcCommand.from_raw_timings(timings[:-1]) is None
 
 
 def test_decode_returns_none_for_invalid_header() -> None:
-    """decode must return None when header matches neither LG standard nor LG2."""
-    timings = [500, -500] + [550, -550] * 28
-    assert decode(timings) is None
+    """from_raw_timings must return None when the header space matches no LG variant."""
+    timings = _build_timings(_SET_COOL_24_AUTO, (3200, 500))
+    assert LgAcCommand.from_raw_timings(timings) is None
 
 
-def test_decode_returns_none_for_bad_checksum() -> None:
-    """decode must return None when the checksum nibble is wrong."""
-    # 0x8800001: valid 0x88 signature but checksum nibble is 1, not 0
-    timings = _encode_frame(0x8800001, _HDR_MARK, _HDR_SPACE)
-    assert decode(timings) is None
+def test_decode_returns_none_for_nec_signal() -> None:
+    """A NEC leader is close enough to the alternate LG header to pass the header gate.
+
+    The signature is what rejects it, so it must keep doing so.
+    """
+    junk = [9000, -4500] + [560, -1690] * 32 + [560]
+    assert LgAcCommand.from_raw_timings(junk) is None
 
 
-def test_decode_returns_none_for_unknown_mode() -> None:
-    """decode must return None when mode nibbles have no mapping."""
-    # (nibs[4], nibs[3]) = (0xF, 0xF) maps to no known mode
-    frame = _checksum(0x88FF000)
-    timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
-    assert decode(timings) is None
-
-
-# ── Decoder: command-nibble variant bit (bit 3 of nibble 3) ───────────────────
+def test_decode_returns_none_for_out_of_tolerance_bit() -> None:
+    """A space matching neither a zero nor a one must reject the frame."""
+    timings = _build_timings(_SET_COOL_24_AUTO)
+    timings[3] = -1000  # between the zero (550) and one (1600) spaces
+    assert LgAcCommand.from_raw_timings(timings) is None
 
 
 @pytest.mark.parametrize(
-    ("nibble3", "expected_mode"),
+    "frame",
     [
-        pytest.param(0x8, LgAcMode.COOL, id="cool_variant"),
-        pytest.param(0x9, LgAcMode.DRY, id="dry_variant"),
-        pytest.param(0xA, LgAcMode.FAN_ONLY, id="fan_only_variant"),
-        pytest.param(0xC, LgAcMode.HEAT, id="heat_variant"),
+        # Valid signature and mode, checksum nibble 0x1 where 0x0 is correct.
+        pytest.param(0x8800001, id="bad_checksum"),
+        # Mode byte 0xFF maps to no LgAcMode; checksum 0xE is correct.
+        pytest.param(0x88FF00E, id="unknown_mode"),
+        # Fan nibble 0xF maps to no LgAcFanSpeed; checksum 0x0 is correct.
+        pytest.param(0x88089F0, id="unknown_fan"),
+        # COOL with temp nibble 0x0 decodes to 15 °C, below MIN_TEMP.
+        pytest.param(0x8800055, id="temp_below_min"),
+        # Display toggle: shares the 0xC0 mode byte with power-off but is not it.
+        pytest.param(0x88C00A6, id="display_toggle"),
     ],
 )
-def test_decode_command_nibble_variant_bit(
-    nibble3: int, expected_mode: LgAcMode
-) -> None:
-    """Bit 3 set in command nibble 3 must decode to the same base mode."""
-    # nibble4 = 0, nibble3 = variant; temp/fan nibbles zero
-    frame = _checksum(0x8800000 | (nibble3 << 12))
-    timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
-    result = decode(timings)
-    assert result is not None
-    assert result.mode == expected_mode
+def test_decode_returns_none_for_invalid_frame(frame: int) -> None:
+    """from_raw_timings must reject frames that fail validation."""
+    assert LgAcCommand.from_raw_timings(_build_timings(frame)) is None

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -3,14 +3,17 @@
 import pytest
 
 from infrared_protocols.commands.lg_ac import (
-    _BIT_MARK,
-    _BIT_ONE_SPACE,
-    _BIT_ZERO_SPACE,
-    _BITS,
     LgAcCommand,
     LgAcFanSpeed,
     LgAcMode,
 )
+
+# Physical-layer constants are duplicated here rather than imported
+# so the tests are independent
+_BITS = 28
+_BIT_MARK = 550
+_BIT_ONE_SPACE = 1600
+_BIT_ZERO_SPACE = 550
 
 _HDR = (3200, 9900)
 _ALT_HDR = (8500, 4250)
@@ -135,6 +138,11 @@ def test_temperature_dropped_for_modes_that_ignore_it(mode: LgAcMode) -> None:
     assert LgAcCommand(mode=mode, temperature=25).temperature is None
 
 
+def test_fan_dropped_for_off() -> None:
+    """OFF is a fixed frame; a fan the caller passes must not be stored."""
+    assert LgAcCommand(mode=LgAcMode.OFF, fan=LgAcFanSpeed.HIGH).fan is None
+
+
 def test_default_modulation() -> None:
     """Default modulation must be 38 kHz."""
     cmd = LgAcCommand(mode=LgAcMode.OFF)
@@ -200,14 +208,14 @@ def test_temperature_out_of_range(temp: int, mode: LgAcMode) -> None:
             LgAcFanSpeed.HIGH,
             id="fan_only_high",
         ),
-        pytest.param(_OFF, LgAcMode.OFF, None, LgAcFanSpeed.AUTO, id="off"),
+        pytest.param(_OFF, LgAcMode.OFF, None, None, id="off"),
         pytest.param(
             _COOL_26_MEDIUM, LgAcMode.COOL, 26, LgAcFanSpeed.MEDIUM, id="cool_26_medium"
         ),
     ],
 )
 def test_decode_captured_frame(
-    frame: int, mode: LgAcMode, temperature: int | None, fan: LgAcFanSpeed
+    frame: int, mode: LgAcMode, temperature: int | None, fan: LgAcFanSpeed | None
 ) -> None:
     """Settings frames and power-on frames must decode to the same state."""
     result = LgAcCommand.from_raw_timings(_build_timings(frame))

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -1,0 +1,211 @@
+"""Tests for the LG air-conditioner IR command and decoder."""
+
+import pytest
+
+from infrared_protocols.commands.lg_ac import (
+    LgAcCommand,
+    LgAcFanSpeed,
+    LgAcMode,
+    LgAcState,
+    MIN_TEMP,
+    _OFF_HDR_MARK,
+    _OFF_HDR_SPACE,
+    _HDR_MARK,
+    _HDR_SPACE,
+    _checksum,
+    _encode_frame,
+    decode,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _extract_frame(timings: list[int]) -> int:
+    """Extract the 28-bit frame integer from raw timings."""
+    frame = 0
+    i = 2
+    bits_read = 0
+    while i + 1 < len(timings) and bits_read < 28:
+        frame = (frame << 1) | (1 if abs(timings[i + 1]) > 1000 else 0)
+        i += 2
+        bits_read += 1
+    return frame
+
+
+# ── Encoder: known-good frame values (verified against hardware captures) ────
+
+
+def test_encode_off_frame() -> None:
+    """Power-off must produce frame 0x88C0051 with LG2-short header."""
+    cmd = LgAcCommand(mode=LgAcMode.OFF)
+    timings = cmd.get_raw_timings()
+    assert timings[0] == _OFF_HDR_MARK
+    assert abs(timings[1]) == _OFF_HDR_SPACE
+    assert _extract_frame(timings) == 0x88C0051
+
+
+def test_encode_cool_24_auto_frame() -> None:
+    """Cool 24 °C / auto fan must produce frame 0x880095E."""
+    cmd = LgAcCommand(mode=LgAcMode.COOL, temperature=24, fan=LgAcFanSpeed.AUTO)
+    assert cmd.get_raw_timings()[0] == _HDR_MARK
+    assert _extract_frame(cmd.get_raw_timings()) == 0x880095E
+
+
+def test_encode_dry_auto_frame() -> None:
+    """Dry / auto fan must produce frame 0x880195F."""
+    cmd = LgAcCommand(mode=LgAcMode.DRY, fan=LgAcFanSpeed.AUTO)
+    assert _extract_frame(cmd.get_raw_timings()) == 0x880195F
+
+
+@pytest.mark.parametrize(
+    ("temp", "fan", "expected_hex"),
+    [
+        pytest.param(18, LgAcFanSpeed.AUTO, 0x8800358, id="18_auto"),
+        pytest.param(30, LgAcFanSpeed.AUTO, 0x8800F54, id="30_auto"),
+        pytest.param(24, LgAcFanSpeed.LOW, 0x8800909, id="24_low"),
+        pytest.param(24, LgAcFanSpeed.MEDIUM, 0x880092B, id="24_medium"),
+        pytest.param(24, LgAcFanSpeed.HIGH, 0x880094D, id="24_high"),
+    ],
+)
+def test_encode_cool_frames(temp: int, fan: LgAcFanSpeed, expected_hex: int) -> None:
+    """Verify cool encoder against known-good frames."""
+    cmd = LgAcCommand(mode=LgAcMode.COOL, temperature=temp, fan=fan)
+    assert _extract_frame(cmd.get_raw_timings()) == expected_hex
+
+
+# ── Encoder: modulation and repeat defaults ───────────────────────────────────
+
+
+def test_default_modulation() -> None:
+    """Default modulation must be 38 kHz."""
+    cmd = LgAcCommand(mode=LgAcMode.OFF)
+    assert cmd.modulation == 38000
+    assert cmd.repeat_count == 0
+
+
+# ── Encoder: validation ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param(LgAcMode.COOL, id="cool"),
+        pytest.param(LgAcMode.HEAT, id="heat"),
+    ],
+)
+def test_temperature_required_for_cool_heat(mode: LgAcMode) -> None:
+    """COOL and HEAT modes must raise when temperature is omitted."""
+    with pytest.raises(ValueError, match="temperature is required"):
+        LgAcCommand(mode=mode)
+
+
+@pytest.mark.parametrize(
+    ("temp", "mode"),
+    [
+        pytest.param(15, LgAcMode.COOL, id="below_min_cool"),
+        pytest.param(31, LgAcMode.COOL, id="above_max_cool"),
+        pytest.param(15, LgAcMode.HEAT, id="below_min_heat"),
+        pytest.param(31, LgAcMode.HEAT, id="above_max_heat"),
+    ],
+)
+def test_temperature_out_of_range(temp: int, mode: LgAcMode) -> None:
+    """Out-of-range temperatures must raise ValueError."""
+    with pytest.raises(ValueError, match="out of range"):
+        LgAcCommand(mode=mode, temperature=temp)
+
+
+# ── Decoder: roundtrips ───────────────────────────────────────────────────────
+
+
+def test_decode_roundtrip_cool() -> None:
+    """Decoded cool frame must reconstruct mode, fan, and temperature."""
+    cmd = LgAcCommand(mode=LgAcMode.COOL, temperature=22, fan=LgAcFanSpeed.HIGH)
+    result = decode(cmd.get_raw_timings())
+    assert result == LgAcState(mode=LgAcMode.COOL, fan=LgAcFanSpeed.HIGH, temp_c=22)
+
+
+def test_decode_roundtrip_off() -> None:
+    """Decoded off frame must return LgAcMode.OFF."""
+    result = decode(LgAcCommand(mode=LgAcMode.OFF).get_raw_timings())
+    assert result is not None
+    assert result.mode == LgAcMode.OFF
+
+
+def test_decode_roundtrip_dry() -> None:
+    """Decoded dry frame must return DRY mode with correct fan."""
+    result = decode(LgAcCommand(mode=LgAcMode.DRY, fan=LgAcFanSpeed.LOW).get_raw_timings())
+    assert result is not None
+    assert result.mode == LgAcMode.DRY
+    assert result.fan == LgAcFanSpeed.LOW
+
+
+def test_decode_roundtrip_heat() -> None:
+    """Decoded heat frame must reconstruct mode, fan, and temperature."""
+    result = decode(
+        LgAcCommand(mode=LgAcMode.HEAT, temperature=26, fan=LgAcFanSpeed.MEDIUM).get_raw_timings()
+    )
+    assert result == LgAcState(mode=LgAcMode.HEAT, fan=LgAcFanSpeed.MEDIUM, temp_c=26)
+
+
+def test_decode_roundtrip_fan_only() -> None:
+    """Decoded fan-only frame must return FAN_ONLY with correct fan speed."""
+    result = decode(LgAcCommand(mode=LgAcMode.FAN_ONLY, fan=LgAcFanSpeed.HIGH).get_raw_timings())
+    assert result is not None
+    assert result.mode == LgAcMode.FAN_ONLY
+    assert result.fan == LgAcFanSpeed.HIGH
+
+
+@pytest.mark.parametrize(
+    ("mode", "temp", "fan"),
+    [
+        pytest.param(LgAcMode.COOL, 24, LgAcFanSpeed.AUTO, id="cool_24_auto"),
+        pytest.param(LgAcMode.COOL, 18, LgAcFanSpeed.LOW, id="cool_18_low"),
+        pytest.param(LgAcMode.COOL, 30, LgAcFanSpeed.HIGH, id="cool_30_high"),
+        pytest.param(LgAcMode.HEAT, 20, LgAcFanSpeed.MEDIUM, id="heat_20_medium"),
+        pytest.param(LgAcMode.HEAT, 28, LgAcFanSpeed.QUIET, id="heat_28_quiet"),
+    ],
+)
+def test_decode_roundtrip_parametrized(
+    mode: LgAcMode, temp: int, fan: LgAcFanSpeed
+) -> None:
+    """Roundtrip encode→decode must preserve mode, fan, and temperature."""
+    cmd = LgAcCommand(mode=mode, temperature=temp, fan=fan)
+    result = decode(cmd.get_raw_timings())
+    assert result == LgAcState(mode=mode, fan=fan, temp_c=temp)
+
+
+# ── Decoder: rejection cases ──────────────────────────────────────────────────
+
+
+def test_decode_returns_none_for_short_timings() -> None:
+    """decode must return None for incomplete signals."""
+    assert decode([500, -400]) is None
+
+
+def test_decode_returns_none_for_non_lg_ac() -> None:
+    """decode must return None for frames with wrong signature."""
+    # NEC-style header (9000/4500) with wrong signature
+    junk = [9000, -4500] + [550, -1600] * 32
+    assert decode(junk) is None
+
+
+def test_decode_returns_none_for_invalid_header() -> None:
+    """decode must return None when header matches neither LG standard nor LG2."""
+    timings = [500, -500] + [550, -550] * 28
+    assert decode(timings) is None
+
+
+def test_decode_returns_none_for_bad_checksum() -> None:
+    """decode must return None when the checksum nibble is wrong."""
+    # 0x8800001: valid 0x88 signature but checksum nibble is 1, not 0
+    timings = _encode_frame(0x8800001, _HDR_MARK, _HDR_SPACE)
+    assert decode(timings) is None
+
+
+def test_decode_returns_none_for_unknown_mode() -> None:
+    """decode must return None when mode nibbles have no mapping."""
+    # (nibs[4], nibs[3]) = (0xF, 0xF) is not in _CMD_NIBS_TO_MODE
+    frame = _checksum(0x88FF000)
+    timings = _encode_frame(frame, _HDR_MARK, _HDR_SPACE)
+    assert decode(timings) is None


### PR DESCRIPTION
Adds `infrared_protocols/commands/lg_ac.py` implementing the LG 28-bit air-conditioner IR protocol.

## What

- `LgAcMode` / `LgAcFanSpeed` enums
- `LgAcCommand` encodes any AC state to raw timings; every frame uses the LG2 header (3200/9900 us). Power-off is a fixed frame, not a different header.
- `LgAcCommand.from_raw_timings(timings) -> Self | None` decodes, matching the pattern of the other command classes. It also accepts the longer 8500/4250 us header that some LG units send.

## Why

Moves LG AC encode/decode logic upstream from the `lg_infrared` Home Assistant integration (PR home-assistant/core#174142), where a reviewer asked for it to live in this library.

## Tests

43 tests covering known-good frame values verified against hardware captures, encode/decode roundtrips for all modes, input validation, and rejection cases.