### PR TITLE
fix: use 8-bit values in Tween Light LED strip codes and resolve duplicates

### DIFF
--- a/infrared_protocols/codes/tween_light/led_strip.py
+++ b/infrared_protocols/codes/tween_light/led_strip.py
@@ -16,30 +16,30 @@ from ...commands.nec import NECCommand
 class TweenLightLEDStripCode(IntEnum):
     """Tween Light LED Strip IR command codes."""
 
-    ON = 0xFC03
-    OFF = 0xFD02
-    BRIGHTNESS_UP = 0xFF00
-    BRIGHTNESS_DOWN = 0xFE01
-    FLASH = 0xF40B
-    STROBE = 0xF00F
-    FADE = 0xEC13
-    SMOOTH = 0xE817
-    RED = 0xFB04
-    GREEN = 0xFA05
-    BLUE = 0xF906
-    WHITE = 0xF708
-    TOMATO = 0xF708
-    LIGHT_GREEN = 0xF609
-    SKY_BLUE = 0xF906
-    ORANGE_RED = 0xF30C
-    CYAN = 0xF20D
-    REBECCA_PURPLE = 0xF10E
-    ORANGE = 0xEF10
-    TURQUOISE = 0xEE11
-    PURPLE = 0xED12
-    YELLOW = 0xEB14
-    DARK_CYAN = 0xEA15
-    PLUM = 0xE916
+    ON = 0x03
+    OFF = 0x02
+    BRIGHTNESS_UP = 0x00
+    BRIGHTNESS_DOWN = 0x01
+    FLASH = 0x0B
+    STROBE = 0x0F
+    FADE = 0x13
+    SMOOTH = 0x17
+    RED = 0x04
+    GREEN = 0x05
+    BLUE = 0x06
+    WHITE = 0x07
+    TOMATO = 0x08
+    LIGHT_GREEN = 0x09
+    SKY_BLUE = 0x0A
+    ORANGE_RED = 0x0C
+    CYAN = 0x0D
+    REBECCA_PURPLE = 0x0E
+    ORANGE = 0x10
+    TURQUOISE = 0x11
+    PURPLE = 0x12
+    YELLOW = 0x14
+    DARK_CYAN = 0x15
+    PLUM = 0x16
 
     def to_command(self, repeat_count: int = 0) -> Command:
         """Build a NEC command."""


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

The command codes stored 16-bit values (command byte + NEC inverse),
but NECCommand only uses the low byte and computes the inverse itself,
making the high byte redundant. Narrow all codes to 8-bit.

This also exposed two duplicate values that IntEnum had silently turned
into aliases.


## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/172803

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
