### PR TITLE
feat: validate NEC address and command byte ranges

### DIFF
--- a/infrared_protocols/commands/nec.py
+++ b/infrared_protocols/commands/nec.py
@@ -31,6 +31,14 @@ class NECCommand(Command):
     ) -> None:
         """Initialize the NEC IR command."""
         super().__init__(modulation=modulation, repeat_count=repeat_count)
+        if not 0 <= address <= 0xFFFF:
+            raise ValueError(
+                f"address must be a 16-bit value (0-0xFFFF), got {address:#x}"
+            )
+        if not 0 <= command <= 0xFF:
+            raise ValueError(
+                f"command must be an 8-bit value (0-0xFF), got {command:#x}"
+            )
         self.address = address
         self.command = command
 

--- a/tests/commands/test_nec.py
+++ b/tests/commands/test_nec.py
@@ -193,6 +193,21 @@ def test_nec_command_get_raw_timings(address: int, expected_frame: list[int]) ->
 
 
 @pytest.mark.parametrize(
+    ("address", "command"),
+    [
+        pytest.param(-1, COMMAND, id="address_negative"),
+        pytest.param(0x10000, COMMAND, id="address_too_large"),
+        pytest.param(STANDARD_ADDRESS, -1, id="command_negative"),
+        pytest.param(STANDARD_ADDRESS, 0x100, id="command_too_large"),
+    ],
+)
+def test_nec_command_rejects_out_of_range(address: int, command: int) -> None:
+    """Test that out-of-range address or command values raise ValueError."""
+    with pytest.raises(ValueError, match="8-bit value|16-bit value"):
+        NECCommand(address=address, command=command)
+
+
+@pytest.mark.parametrize(
     ("frame", "expected_address"),
     [
         pytest.param(STANDARD_FRAME, STANDARD_DECODED_ADDRESS, id="standard"),


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

Reject out-of-range address (0-0xFFFF) and command (0-0xFF) values at
construction since they are truncated in get_raw_timings.


## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: N/A

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
