### PR TITLE
feat: add Edifier S3000 Pro

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -11,6 +11,7 @@ class EdifierCommandSet(StrEnum):
     R1280T = "r1280t"
     S360DB = "s360db"
     RC20G = "rc20g"
+    S3000PRO = "s3000pro"
 
 
 class EdifierModel(StrEnum):
@@ -34,6 +35,8 @@ class EdifierModel(StrEnum):
     RC31A = "RC31A"
     # RC20G command set (unique left/right volume controls)
     RC20G = "RC20G"
+    # S3000 Pro command set (RCA10B remote)
+    S3000PRO = "S3000 Pro"
 
 
 MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
@@ -55,4 +58,6 @@ MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
     EdifierModel.RC31A: EdifierCommandSet.S360DB,
     # RC20G command set
     EdifierModel.RC20G: EdifierCommandSet.RC20G,
+    # S3000 Pro command set
+    EdifierModel.S3000PRO: EdifierCommandSet.S3000PRO,
 }

--- a/infrared_protocols/codes/edifier/s3000pro.py
+++ b/infrared_protocols/codes/edifier/s3000pro.py
@@ -1,0 +1,33 @@
+"""Command codes for the Edifier S3000 Pro remote (model RCA10B).
+
+The Line/Bal and Opt/Coax buttons each toggle between their two inputs.
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class EdifierS3000ProCode(IntEnum):
+    """Edifier S3000 Pro remote IR command codes."""
+
+    POWER = 0x43
+    VOLUME_UP = 0x4C
+    VOLUME_DOWN = 0x17
+    MUTE = 0x40
+    PLAY_PAUSE = 0x50
+    NEXT = 0x13
+    PREVIOUS = 0x54
+    LINE_BAL = 0x51
+    OPT_COAX = 0x12
+    USB = 0x8D
+    BLUETOOTH = 0x0C
+    EQ_MONITOR = 0x16
+    EQ_DYNAMIC = 0x55
+    EQ_CLASSIC = 0x0E
+    EQ_VOCAL = 0x4D
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NECCommand."""
+        return NECCommand(address=0xE710, command=self.value, repeat_count=repeat_count)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

Adds IR codes for Edifier S3000 Pro

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/175425

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
