### PR TITLE
Add support for Edifier R1380DB / RC13D

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -7,6 +7,7 @@ class EdifierCommandSet(StrEnum):
     """Edifier command set groupings."""
 
     R1700BT = "r1700bt"
+    R1380DB = "r3280db"
     R1280DB = "r1280db"
     R1280T = "r1280t"
     S360DB = "s360db"
@@ -22,6 +23,9 @@ class EdifierModel(StrEnum):
     RC17A = "RC17A"
     RC80B = "RC80B"
     R1855DB = "R1855DB"
+    # R1380DB command set
+    R1380DB = "R1380DB"
+    RC13D = "R1380DB"
     # R1280DB command set
     R1280DB = "R1280DB"
     R2730DB = "R2730DB"
@@ -43,6 +47,9 @@ MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
     EdifierModel.RC17A: EdifierCommandSet.R1700BT,
     EdifierModel.RC80B: EdifierCommandSet.R1700BT,
     EdifierModel.R1855DB: EdifierCommandSet.R1700BT,
+    # R1380DB command set
+    EdifierModel.R1380DB: EdifierCommandSet.R1380DB,
+    EdifierModel.RC13D: EdifierCommandSet.R1380DB,
     # R1280DB command set
     EdifierModel.R1280DB: EdifierCommandSet.R1280DB,
     EdifierModel.R2730DB: EdifierCommandSet.R1280DB,

--- a/infrared_protocols/codes/edifier/r1380db.py
+++ b/infrared_protocols/codes/edifier/r1380db.py
@@ -1,0 +1,30 @@
+"""Command codes for Edifier R1380DB speakers.
+
+Command set used by R1380DB (remote model RC13D).
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class EdifierR1380DBCode(IntEnum):
+    """Edifier R1380DB speaker IR command codes."""
+
+    POWER = 0xB946
+    VOLUME_UP = 0xF906
+    VOLUME_DOWN = 0xB847
+    MUTE = 0xBE41
+    PLAY_PAUSE = 0xA05F
+    FORWARD = 0xA25D
+    BACK = 0xBB44
+    LINE_1 = 0xE51A
+    LINE_2 = 0xE41B
+    COAX = 0xF20D
+    OPTICAL = 0xEA15
+    BLUETOOTH = 0xA35C
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NECCommand."""
+        return NECCommand(address=0xE710, command=self.value, repeat_count=repeat_count)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

This just adds an extra Edifier speaker/amplifier; Specifically the R1380DB.
Of note, the remote says "RC13D", so I assume it will work for a few other models, but I have no idea which ones.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

I don't have a draft PR against home-assistant/core as I believe this is a small enough change and shouldn't really affect that repo directly.

I don't know how to properly test this in my running hassos system against the speakers, but I've run `pytest` and the Python code itself is clean.

Closes https://github.com/home-assistant-libs/infrared-protocols/issues/73

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [ ] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
