### PR TITLE
Fix Pronto short overflow from ambient radiation

### DIFF
--- a/infrared_protocols/commands/pronto.py
+++ b/infrared_protocols/commands/pronto.py
@@ -63,7 +63,10 @@ class ProntoCommand(Command):
 
     @staticmethod
     def _int_to_pronto(value: int) -> bytes:
-        return struct.pack(">h", value)
+        try:
+            return struct.pack(">h", value)
+        except struct.error as err:
+            raise ValueError("Invalid data.") from err
 
     @staticmethod
     def _pronto_to_int(pronto_block: bytes) -> int:


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

This PR catches a parsing error correctly which was previously uncaught and led to integrations using this code dying. That is especially catchy as this occured with ambient IR radiation on a sunny day.

I didn't bring it up earlier for #59 as that PR was previously rejected.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: ø

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
