### PR TITLE
fix: add Pronto HEX command API

### DIFF
--- a/infrared_protocols/commands/pronto.py
+++ b/infrared_protocols/commands/pronto.py
@@ -1,146 +1,262 @@
-"""Pronto IR command code format."""
+"""Pronto HEX command support.
 
-import struct
-from textwrap import wrap
-from typing import Self, override
+Public API:
+- ProntoCommand: Command implementation for learned/raw Pronto HEX type 0000.
+- ProntoCommand(pronto_hex=...): create a command from complete Pronto HEX.
+- ProntoCommand.from_raw_timings(...): create a command from signed raw timings.
+- decode_pronto_hex(...): decode Pronto HEX into modulation and signed timings.
+- encode_pronto_hex(...): encode signed raw timings as Pronto HEX.
+- ProntoCode: decoded modulation and signed timing data.
+- ProntoError: raised for malformed or unsupported Pronto data.
+
+Only learned/raw Pronto HEX type 0000 is supported. Public timings use the
+infrared-protocols signed convention: positive values are marks, negative values
+are spaces, and durations are in microseconds.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Self
 
 from . import Command
 
-PRONTO_PREAMBLE_LEARNED_TOKEN = b"\x00\x00"
-# To get the unit pulse length in microseconds,
-# divide 1000 * 1000 (microseconds per second) by reference frequency
-PRONTO_REFERENCE_FREQUENCY = 4145146
-PRONTO_DEFAULT_FREQUENCY = 38000
+__all__ = [
+    "ProntoCode",
+    "ProntoCommand",
+    "ProntoError",
+    "decode_pronto_hex",
+    "encode_pronto_hex",
+]
+
+_PRONTO_TYPE_LEARNED_RAW = 0x0000
+_PRONTO_FREQUENCY_REFERENCE_US = 0.241246
+_PRONTO_HEADER_WORD_COUNT = 4
+_PRONTO_MAX_WORD = 0xFFFF
+
+_DEFAULT_MODULATION = 38_000
+_DEFAULT_TRAILING_GAP_US = 100_000
+
+
+@dataclass(frozen=True, slots=True)
+class ProntoCode:
+    """Decoded Pronto modulation and signed timing data."""
+
+    modulation: int
+    timings: tuple[int, ...]
+
+
+class ProntoError(ValueError):
+    """Raised when Pronto data cannot be parsed or generated."""
 
 
 class ProntoCommand(Command):
-    """Pronto IR command.
-
-    A pronto code consists of a 4 word preamble and timing data.
-    A data word of pronto is 2 bytes long.
-    Two data words (4 bytes) encode one content bit.
-    The preamble consists of:
-    1 word indicating the token source (currently supported: learned).
-    1 word indicating the modulation frequency.
-    1 word indicating the length of the timing data in content bits.
-    1 word indicating the amount of repeats of the timing data.
-    After the preamble, the timing data follows in pairs of two words
-    (mark and space duration).
-
-    Most of the code has been ported from the ESPHome sources at
-    https://github.com/esphome/esphome/blob/dev/esphome/components/remote_base/pronto_protocol.cpp.
-    """
-
-    timing_data: bytes
+    """Command implementation for learned/raw Pronto HEX type 0000."""
 
     def __init__(
         self,
         *,
-        timing_data: bytes,
-        modulation: int = PRONTO_DEFAULT_FREQUENCY,
+        pronto_hex: str,
         repeat_count: int = 0,
     ) -> None:
-        """Initialize the Pronto IR command."""
-        super().__init__(modulation=modulation, repeat_count=repeat_count)
-        self.timing_data = timing_data
-
-    def __repr__(self) -> str:
-        """Get string representation for this pronto code."""
-        content_bytes_hex = b"".join(
-            [
-                PRONTO_PREAMBLE_LEARNED_TOKEN,
-                ProntoCommand._int_to_pronto(
-                    value=round(PRONTO_REFERENCE_FREQUENCY / self.modulation)
-                ),  # Modulation
-                ProntoCommand._int_to_pronto(
-                    value=int(len(self.timing_data) / 4)
-                ),  # in content bits
-                ProntoCommand._int_to_pronto(value=self.repeat_count),  # repeats
-                self.timing_data,
-            ]
-        ).hex()
-        return " ".join(wrap(content_bytes_hex, 4))
-
-    @staticmethod
-    def _int_to_pronto(value: int) -> bytes:
-        return struct.pack(">h", value)
-
-    @staticmethod
-    def _pronto_to_int(pronto_block: bytes) -> int:
-        return struct.unpack(">h", pronto_block)[0]
-
-    @staticmethod
-    def _time_base(modulation: int) -> float:
-        """Calculate base pulse length in microseconds for a given modulation."""
-        return 1000000 / modulation
-
-    @staticmethod
-    def _compensate_duration(value: int, time_base: float) -> int:
-        """Compensate positive/negative durations to positive ones."""
-        if value > 0:
-            result = value - 20
-        else:
-            result = -value + 20
-        return round((result + time_base / 2) / time_base)
-
-    @override
-    def get_raw_timings(self) -> list[int]:
-        """Get raw timings for the Pronto command.
-
-        Durations are encoded in the pronto timing data and only need to be converted.
-        """
-        time_base = ProntoCommand._time_base(self.modulation)
-        return [
-            symbol
-            for value in zip(
-                self.timing_data[::4],
-                self.timing_data[1::4],
-                self.timing_data[2::4],
-                self.timing_data[3::4],
-                strict=True,
-            )
-            for symbol in (
-                # mark
-                min(
-                    round(
-                        ProntoCommand._pronto_to_int(pronto_block=bytes(value[:2]))
-                        * time_base
-                    ),
-                    0xFFFF,
-                ),
-                # space
-                -min(
-                    round(
-                        ProntoCommand._pronto_to_int(pronto_block=bytes(value[2:]))
-                        * time_base
-                    ),
-                    0xFFFF,
-                ),
-            )
-        ] * (self.repeat_count + 1)
+        """Initialize a command from complete Pronto HEX."""
+        decoded = decode_pronto_hex(pronto_hex)
+        super().__init__(
+            modulation=decoded.modulation,
+            repeat_count=repeat_count,
+        )
+        self._timings = decoded.timings
+        self._pronto_hex = _normalize_pronto_hex(pronto_hex)
 
     @classmethod
     def from_raw_timings(
-        cls, timings: list[int], modulation: int | None = None
+        cls,
+        timings: Iterable[int],
+        modulation: int = _DEFAULT_MODULATION,
+        *,
+        repeat_count: int = 0,
+        trailing_gap_us: int | None = _DEFAULT_TRAILING_GAP_US,
     ) -> Self:
-        """Decode raw IR timings into a ProntoCommand.
-
-        If modulation is None, the typical 38000 kHz are used.
-        Returns a ProntoCommand.
-        """
-        if modulation is None:
-            modulation = PRONTO_DEFAULT_FREQUENCY
-        time_base = ProntoCommand._time_base(modulation=modulation)
-        timing_data = b"".join(
-            ProntoCommand._int_to_pronto(
-                value=ProntoCommand._compensate_duration(
-                    value=timing, time_base=time_base
-                )
-            )
-            for timing in timings
-        )
+        """Create a command from signed raw timings."""
         return cls(
-            timing_data=timing_data,
-            modulation=modulation,
-            repeat_count=0,
+            pronto_hex=encode_pronto_hex(
+                timings,
+                modulation,
+                trailing_gap_us=trailing_gap_us,
+            ),
+            repeat_count=repeat_count,
         )
+
+    def get_raw_timings(self) -> list[int]:
+        """Return signed raw timings for this command."""
+        return list(self._timings) * (self.repeat_count + 1)
+
+    def to_pronto_hex(self) -> str:
+        """Return normalized learned/raw Pronto HEX."""
+        return self._pronto_hex
+
+    def __str__(self) -> str:
+        """Return normalized learned/raw Pronto HEX."""
+        return self.to_pronto_hex()
+
+
+def decode_pronto_hex(pronto_hex: str) -> ProntoCode:
+    """Decode learned/raw Pronto HEX type 0000."""
+    words = _parse_pronto_words(pronto_hex)
+
+    if len(words) < _PRONTO_HEADER_WORD_COUNT:
+        raise ProntoError("Pronto HEX is too short")
+
+    pronto_type, frequency_word, intro_pairs, repeat_pairs = words[:4]
+
+    if pronto_type != _PRONTO_TYPE_LEARNED_RAW:
+        raise ProntoError("Only learned/raw Pronto HEX type 0000 is supported")
+
+    if frequency_word <= 0:
+        raise ProntoError("Pronto frequency word must be greater than zero")
+
+    pair_count = intro_pairs + repeat_pairs
+    if pair_count <= 0:
+        raise ProntoError("Pronto HEX must contain at least one timing pair")
+
+    timing_words = words[_PRONTO_HEADER_WORD_COUNT:]
+    expected_timing_word_count = pair_count * 2
+
+    if len(timing_words) != expected_timing_word_count:
+        raise ProntoError("Pronto timing word count does not match header")
+
+    if any(word <= 0 for word in timing_words):
+        raise ProntoError("Pronto timing words must be greater than zero")
+
+    modulation = round(
+        1_000_000 / (frequency_word * _PRONTO_FREQUENCY_REFERENCE_US)
+    )
+    timings = tuple(
+        _apply_timing_sign(index, _pronto_word_to_microseconds(word, frequency_word))
+        for index, word in enumerate(timing_words)
+    )
+
+    return ProntoCode(modulation=modulation, timings=timings)
+
+
+def _parse_pronto_words(pronto_hex: str) -> list[int]:
+    """Parse Pronto HEX words."""
+    if not pronto_hex.strip():
+        raise ProntoError("Pronto HEX cannot be empty")
+
+    words: list[int] = []
+
+    for word in pronto_hex.split():
+        if len(word) != 4 or any(
+            character not in "0123456789abcdefABCDEF" for character in word
+        ):
+            raise ProntoError("Pronto HEX words must contain four hex digits")
+
+        words.append(int(word, 16))
+
+    return words
+
+
+def _normalize_pronto_hex(pronto_hex: str) -> str:
+    """Return normalized uppercase Pronto HEX."""
+    return " ".join(f"{word:04X}" for word in _parse_pronto_words(pronto_hex))
+
+
+def _pronto_word_to_microseconds(word: int, frequency_word: int) -> int:
+    """Convert a Pronto timing word to microseconds."""
+    return round(word * frequency_word * _PRONTO_FREQUENCY_REFERENCE_US)
+
+
+def _apply_timing_sign(index: int, timing: int) -> int:
+    """Apply signed mark/space timing convention."""
+    return timing if index % 2 == 0 else -timing
+
+
+def encode_pronto_hex(
+    timings: Iterable[int],
+    modulation: int,
+    *,
+    trailing_gap_us: int | None = _DEFAULT_TRAILING_GAP_US,
+) -> str:
+    """Encode signed raw timings as learned/raw Pronto HEX type 0000."""
+    frequency_word = _modulation_to_frequency_word(modulation)
+    timing_durations = _normalize_encode_timings(timings, trailing_gap_us)
+
+    pair_count = len(timing_durations) // 2
+    if pair_count > _PRONTO_MAX_WORD:
+        raise ProntoError("Pronto timing pair count exceeds 16-bit value")
+
+    timing_words = [
+        _microseconds_to_pronto_word(duration, frequency_word)
+        for duration in timing_durations
+    ]
+
+    words = [
+        _PRONTO_TYPE_LEARNED_RAW,
+        frequency_word,
+        pair_count,
+        0x0000,
+        *timing_words,
+    ]
+
+    return " ".join(f"{word:04X}" for word in words)
+
+
+def _modulation_to_frequency_word(modulation: int) -> int:
+    """Convert modulation frequency to a Pronto frequency word."""
+    if type(modulation) is not int or modulation <= 0:
+        raise ProntoError("modulation must be a positive integer")
+
+    frequency_word = round(
+        1_000_000 / (modulation * _PRONTO_FREQUENCY_REFERENCE_US)
+    )
+
+    if frequency_word <= 0:
+        raise ProntoError("Pronto frequency word must be greater than zero")
+
+    if frequency_word > _PRONTO_MAX_WORD:
+        raise ProntoError("Pronto frequency word exceeds 16-bit value")
+
+    return frequency_word
+
+
+def _normalize_encode_timings(
+    timings: Iterable[int],
+    trailing_gap_us: int | None,
+) -> list[int]:
+    """Normalize raw timings for Pronto encoding."""
+    timing_durations = [_normalize_duration(timing) for timing in timings]
+
+    if not timing_durations:
+        raise ProntoError("timings cannot be empty")
+
+    if len(timing_durations) % 2:
+        if trailing_gap_us is None:
+            raise ProntoError("timings must contain mark/space pairs")
+
+        timing_durations.append(_normalize_duration(-trailing_gap_us))
+
+    return timing_durations
+
+
+def _normalize_duration(timing: int) -> int:
+    """Normalize a signed timing to an unsigned Pronto duration."""
+    if type(timing) is not int:
+        raise ProntoError("timings must be integers")
+
+    if timing == 0:
+        raise ProntoError("timings must be non-zero")
+
+    return abs(timing)
+
+
+def _microseconds_to_pronto_word(duration: int, frequency_word: int) -> int:
+    """Convert microseconds to a Pronto timing word."""
+    word = round(duration / (frequency_word * _PRONTO_FREQUENCY_REFERENCE_US))
+
+    if word <= 0:
+        raise ProntoError("Pronto timing word must be greater than zero")
+
+    if word > _PRONTO_MAX_WORD:
+        raise ProntoError("Pronto timing word exceeds 16-bit value")
+
+    return word

--- a/infrared_protocols/commands/pronto.py
+++ b/infrared_protocols/commands/pronto.py
@@ -127,9 +127,7 @@ def decode_pronto_hex(pronto_hex: str) -> ProntoCode:
     if any(word <= 0 for word in timing_words):
         raise ProntoError("Pronto timing words must be greater than zero")
 
-    modulation = round(
-        1_000_000 / (frequency_word * _PRONTO_FREQUENCY_REFERENCE_US)
-    )
+    modulation = round(1_000_000 / (frequency_word * _PRONTO_FREQUENCY_REFERENCE_US))
     timings = tuple(
         _apply_timing_sign(index, _pronto_word_to_microseconds(word, frequency_word))
         for index, word in enumerate(timing_words)
@@ -206,9 +204,7 @@ def _modulation_to_frequency_word(modulation: int) -> int:
     if type(modulation) is not int or modulation <= 0:
         raise ProntoError("modulation must be a positive integer")
 
-    frequency_word = round(
-        1_000_000 / (modulation * _PRONTO_FREQUENCY_REFERENCE_US)
-    )
+    frequency_word = round(1_000_000 / (modulation * _PRONTO_FREQUENCY_REFERENCE_US))
 
     if frequency_word <= 0:
         raise ProntoError("Pronto frequency word must be greater than zero")

--- a/tests/commands/test_pronto.py
+++ b/tests/commands/test_pronto.py
@@ -1,37 +1,185 @@
-from infrared_protocols.commands.pronto import ProntoCommand
+"""Tests for Pronto HEX command support."""
 
-TEST_DATA_KNOWN_GOOD_RAW_TIMINGS = [
-    9100, -4446, 598, -494, 598, -494, 598, -494, 598, -1612, 598, -494, 598, -494, 598,
-    -1612, 598, -494, 598, -494, 598, -1612, 598, -494, 598, -494, 598, -494, 598, -494,
-    598, -494, 598, -1612, 598, -1612, 598, -494, 598, -494, 598, -494, 598, -494, 598,
-    -494, 598, -494, 598, -1612, 598, -494, 598, -494, 598, -494, 598, -1612, 598, -494,
-    598, -494, 598, -494, 598, -494, 598, -9984
-]
-TEST_DATA_KNOWN_GOOD_MODULATION = 38000
-TEST_DATA_KNOWN_GOOD_REPEATS = 0
-TEST_DATA_KNOWN_GOOD_PRONTO = b'\x01Z\x00\xaa\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00?\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x00\x14\x00\x16\x01}'
-TEST_DATA_KNOWN_GOOD_PRONTO_REPR = "0000 006d 0022 0000 015a 00aa 0016 0014 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 0014 0016 0014 0016 0014 0016 003f 0016 003f 0016 0014 0016 0014 0016 0014 0016 0014 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 0014 0016 003f 0016 0014 0016 0014 0016 0014 0016 0014 0016 017d"
+import pytest
 
-def test_encode_pronto_from_timing():
-    pronto = ProntoCommand.from_raw_timings(TEST_DATA_KNOWN_GOOD_RAW_TIMINGS)
-    assert pronto.modulation == TEST_DATA_KNOWN_GOOD_MODULATION
-    assert pronto.repeat_count == TEST_DATA_KNOWN_GOOD_REPEATS
-    assert pronto.timing_data == TEST_DATA_KNOWN_GOOD_PRONTO
+from infrared_protocols.commands.pronto import (
+    ProntoCode,
+    ProntoCommand,
+    ProntoError,
+    decode_pronto_hex,
+    encode_pronto_hex,
+)
 
-def test_decode_pronto_to_timing():
-    pronto = ProntoCommand(timing_data=TEST_DATA_KNOWN_GOOD_PRONTO, modulation=TEST_DATA_KNOWN_GOOD_MODULATION, repeat_count=TEST_DATA_KNOWN_GOOD_REPEATS)
-    assert pronto.modulation == 38000
-    assert pronto.repeat_count == TEST_DATA_KNOWN_GOOD_REPEATS
-    assert all(abs(calculated - expected) < 2 * ProntoCommand._time_base(modulation=pronto.modulation) for calculated, expected in zip(pronto.get_raw_timings(), TEST_DATA_KNOWN_GOOD_RAW_TIMINGS, strict=True))
+SIMPLE_PRONTO_HEX = "0000 006D 0002 0000 0156 00AB 0015 0015"
+SIMPLE_RAW_TIMINGS = (8993, -4497, 552, -552)
+RAW_TIMINGS = (9000, -4500, 562, -562)
 
-def test_pronto_repr():
-    pronto = ProntoCommand.from_raw_timings(TEST_DATA_KNOWN_GOOD_RAW_TIMINGS)
-    assert repr(pronto) == TEST_DATA_KNOWN_GOOD_PRONTO_REPR
 
-def test_pronto_repeats():
-    # Repeats only work correctly if pronto is constructed using the default constructor, not by using ProntoCommand.from_raw_timings.
-    pronto = ProntoCommand(timing_data=TEST_DATA_KNOWN_GOOD_PRONTO, modulation=TEST_DATA_KNOWN_GOOD_MODULATION, repeat_count=2)
-    assert pronto.repeat_count == 2
-    # 1 base + 2 repeats
-    assert len(pronto.get_raw_timings()) == (1 + 2) * len(TEST_DATA_KNOWN_GOOD_RAW_TIMINGS)
-    assert all(abs(calculated - expected) < 2 * ProntoCommand._time_base(modulation=pronto.modulation) for calculated, expected in zip(pronto.get_raw_timings(), TEST_DATA_KNOWN_GOOD_RAW_TIMINGS * (1 + 2), strict=True))
+def _assert_timings_close(
+    actual: list[int] | tuple[int, ...],
+    expected: list[int] | tuple[int, ...],
+    *,
+    tolerance: int = 30,
+) -> None:
+    """Assert raw timings are close enough after Pronto rounding."""
+    assert len(actual) == len(expected)
+
+    for actual_timing, expected_timing in zip(actual, expected, strict=True):
+        assert abs(actual_timing - expected_timing) <= tolerance
+
+
+def test_decode_pronto_hex() -> None:
+    """Test decoding learned/raw Pronto HEX."""
+    decoded = decode_pronto_hex(SIMPLE_PRONTO_HEX)
+
+    assert isinstance(decoded, ProntoCode)
+    assert decoded.modulation == 38029
+    assert decoded.timings == SIMPLE_RAW_TIMINGS
+
+
+def test_pronto_command_from_pronto_hex() -> None:
+    """Test creating a Pronto command from Pronto HEX."""
+    command = ProntoCommand(pronto_hex=SIMPLE_PRONTO_HEX)
+
+    assert command.modulation == 38029
+    assert command.repeat_count == 0
+    assert command.get_raw_timings() == list(SIMPLE_RAW_TIMINGS)
+
+
+def test_pronto_command_normalizes_pronto_hex() -> None:
+    """Test Pronto HEX is normalized."""
+    command = ProntoCommand(pronto_hex=SIMPLE_PRONTO_HEX.lower())
+
+    assert command.to_pronto_hex() == SIMPLE_PRONTO_HEX
+    assert str(command) == SIMPLE_PRONTO_HEX
+
+
+def test_encode_pronto_hex() -> None:
+    """Test encoding signed raw timings as Pronto HEX."""
+    assert (
+        encode_pronto_hex(RAW_TIMINGS, 38_000, trailing_gap_us=None)
+        == SIMPLE_PRONTO_HEX
+    )
+
+
+def test_pronto_command_from_raw_timings() -> None:
+    """Test creating a Pronto command from signed raw timings."""
+    command = ProntoCommand.from_raw_timings(
+        RAW_TIMINGS,
+        modulation=38_000,
+        trailing_gap_us=None,
+    )
+
+    assert command.to_pronto_hex() == SIMPLE_PRONTO_HEX
+    assert command.modulation == 38029
+    _assert_timings_close(command.get_raw_timings(), RAW_TIMINGS)
+
+
+def test_pronto_command_repeats_full_timing_sequence() -> None:
+    """Test repeat count repeats the full raw timing sequence."""
+    command = ProntoCommand(pronto_hex=SIMPLE_PRONTO_HEX, repeat_count=2)
+
+    assert command.repeat_count == 2
+    assert command.get_raw_timings() == list(SIMPLE_RAW_TIMINGS) * 3
+
+
+def test_encode_pronto_hex_adds_default_trailing_gap() -> None:
+    """Test an odd timing count gets a default trailing gap."""
+    pronto_hex = encode_pronto_hex([9000, -4500, 562], 38_000)
+
+    words = pronto_hex.split()
+    assert words[:4] == ["0000", "006D", "0002", "0000"]
+
+    command = ProntoCommand(pronto_hex=pronto_hex)
+    timings = command.get_raw_timings()
+
+    assert len(timings) == 4
+    assert timings[2] > 0
+    assert timings[3] < 0
+    assert abs(abs(timings[3]) - 100_000) <= 30
+
+
+def test_encode_pronto_hex_rejects_odd_timings_without_trailing_gap() -> None:
+    """Test odd timing counts are rejected without a trailing gap."""
+    with pytest.raises(ProntoError):
+        encode_pronto_hex([9000, -4500, 562], 38_000, trailing_gap_us=None)
+
+
+@pytest.mark.parametrize(
+    "pronto_hex",
+    [
+        "",
+        "0100 006D 0002 0000 0156 00AB 0015 0015",
+        "0000 0000 0002 0000 0156 00AB 0015 0015",
+        "0000 006D 0000 0000",
+        "0000 006D 0002 0000 0156 00AB",
+        "0000 006D 0001 0000 0000 00AB",
+        "0000 006D 0001 0000 0156 ZZZZ",
+        "0000 006D 0001 0000 0156 -001",
+        "0000 006D 0001 0000 0156 10000",
+    ],
+)
+def test_decode_pronto_hex_rejects_invalid_data(pronto_hex: str) -> None:
+    """Test invalid Pronto HEX data is rejected."""
+    with pytest.raises(ProntoError):
+        decode_pronto_hex(pronto_hex)
+
+
+@pytest.mark.parametrize("modulation", [0, -1, True, 38_000.0])
+def test_encode_pronto_hex_rejects_invalid_modulation(
+    modulation: int | float | bool,
+) -> None:
+    """Test invalid modulation values are rejected."""
+    with pytest.raises(ProntoError):
+        encode_pronto_hex(RAW_TIMINGS, modulation)
+
+
+@pytest.mark.parametrize(
+    "timings",
+    [
+        [],
+        [9000, 0],
+        [True, -4500],
+        [9000.0, -4500],
+    ],
+)
+def test_encode_pronto_hex_rejects_invalid_timings(
+    timings: list[int | float | bool],
+) -> None:
+    """Test invalid raw timing values are rejected."""
+    with pytest.raises(ProntoError):
+        encode_pronto_hex(timings, 38_000)
+
+def test_decode_pronto_hex_rejects_short_header() -> None:
+    """Test Pronto HEX shorter than the header is rejected."""
+    with pytest.raises(ProntoError):
+        decode_pronto_hex("0000 006D 0001")
+
+@pytest.mark.parametrize("modulation", [1, 1_000_000_000])
+def test_encode_pronto_hex_rejects_unencodable_modulation(
+    modulation: int,
+) -> None:
+    """Test modulation values outside Pronto frequency-word range are rejected."""
+    with pytest.raises(ProntoError):
+        encode_pronto_hex(RAW_TIMINGS, modulation)
+
+@pytest.mark.parametrize(
+    "timings",
+    [
+        [1, -1],
+        [10_000_000, -10_000_000],
+    ],
+)
+def test_encode_pronto_hex_rejects_unencodable_timings(
+    timings: list[int],
+) -> None:
+    """Test timings outside Pronto timing-word range are rejected."""
+    with pytest.raises(ProntoError):
+        encode_pronto_hex(timings, 38_000)
+
+def test_encode_pronto_hex_rejects_too_many_timing_pairs() -> None:
+    """Test timing pair count must fit in a Pronto word."""
+    timings = [562, -562] * 65_536
+
+    with pytest.raises(ProntoError):
+        encode_pronto_hex(timings, 38_000)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->
Add a cleaner Pronto HEX command API.

This replaces the previous timing-payload-oriented ProntoCommand API with an API that works with complete learned/raw Pronto HEX type 0000 strings.

Changes:
- Add ProntoCommand(pronto_hex=...)
- Add ProntoCommand.from_raw_timings(...)
- Add ProntoCommand.to_pronto_hex()
- Add decode_pronto_hex(...) and encode_pronto_hex(...)
- Use signed raw timings consistently at the public API boundary
- Add validation for malformed or unsupported Pronto data
- Replace Pronto tests and cover the new API at 100%

Only learned/raw Pronto HEX type 0000 is supported.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/173576

## Checklist

- [X] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [X] Lint, format, and type checks pass (`prek --all-files`).
- [X] Tests pass (`pytest`).
