### PR TITLE
feat!: move Tween Light to generic

### DIFF
--- a/infrared_protocols/codes/generic/led/__init__.py
+++ b/infrared_protocols/codes/generic/led/__init__.py
@@ -1,0 +1,6 @@
+"""Generic LED remote control IR command codes."""
+
+from .generic_13_key import Generic13KeyCode
+from .generic_24_key import Generic24KeyCode
+
+__all__ = ["Generic13KeyCode", "Generic24KeyCode"]

--- a/infrared_protocols/codes/generic/led/generic_24_key.py
+++ b/infrared_protocols/codes/generic/led/generic_24_key.py
@@ -1,20 +1,13 @@
-"""Command codes for Tween Light LED Strip.
-
-Tween light is a brand marketed by the european home improvement retail chain BAUHAUS.
-The LED strip comes with a 24-key remote control, which is also sold with many other
-no-name LED controllers.
-
-https://www.bauhaus.info/led-streifen/tween-light-led-band/p/30293612
-"""
+"""Command codes for generic 24-key LED remote control."""
 
 from enum import IntEnum
 
-from ...commands import Command
-from ...commands.nec import NECCommand
+from ....commands import Command
+from ....commands.nec import NECCommand
 
 
-class TweenLightLEDStripCode(IntEnum):
-    """Tween Light LED Strip IR command codes."""
+class Generic24KeyCode(IntEnum):
+    """Generic 24-key LED remote control IR command codes."""
 
     ON = 0x03
     OFF = 0x02


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

Moves the codes for the generic 24-key remote from tween_light module to generic.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/175294

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
