### PR TITLE
feat: add codes for generic 40-key remote

### DIFF
--- a/infrared_protocols/codes/generic/led/__init__.py
+++ b/infrared_protocols/codes/generic/led/__init__.py
@@ -2,5 +2,6 @@
 
 from .generic_13_key import Generic13KeyCode
 from .generic_24_key import Generic24KeyCode
+from .generic_40_key import Generic40KeyCode
 
-__all__ = ["Generic13KeyCode", "Generic24KeyCode"]
+__all__ = ["Generic13KeyCode", "Generic24KeyCode", "Generic40KeyCode"]

--- a/infrared_protocols/codes/generic/led/generic_40_key.py
+++ b/infrared_protocols/codes/generic/led/generic_40_key.py
@@ -1,0 +1,64 @@
+"""Command codes for generic 40-key LED remote control."""
+
+from enum import IntEnum
+
+from ....commands import Command
+from ....commands.nec import NECCommand
+
+
+class Generic40KeyCode(IntEnum):
+    """Generic 40-key LED remote control IR command codes."""
+
+    ON = 0x40
+    OFF = 0x41
+
+    BRIGHTNESS_UP = 0x5C
+    BRIGHTNESS_DOWN = 0x5D
+
+    WHITE_BRIGHTNESS_UP = 0x14
+    WHITE_BRIGHTNESS_DOWN = 0x15
+    WHITE_ON = 0x16
+    WHITE_OFF = 0x17
+    WHITE_BRIGHTNESS_25 = 0x10
+    WHITE_BRIGHTNESS_50 = 0x11
+    WHITE_BRIGHTNESS_75 = 0x12
+    WHITE_BRIGHTNESS_100 = 0x13
+
+    QUICK = 0x0F
+    SLOW = 0x0B
+
+    JUMP3 = 0x0C
+    FADE3 = 0xDF
+    JUMP7 = 0x0E
+    FADE7 = 0x08
+    FLASH = 0x0B
+    AUTO = 0x0A
+
+    RED = 0x58
+    GREEN = 0x59
+    BLUE = 0x45
+    WHITE = 0x44
+    TOMATO = 0x54
+    LIGHT_GREEN = 0x55
+    DEEP_BLUE = 0x49
+    FLORAL_WHITE = 0x48
+    ORANGE = 0x50
+    TURQUOISE = 0x51
+    PURPLE = 0x4D
+    LAVENDER_BLUSH = 0x4C
+    YELLOWISH = 0x1C
+    CYAN = 0x1D
+    MAGENTA = 0x1E
+    GHOST_WHITE = 0x1F
+    YELLOW = 0x18
+    AQUA = 0x19
+    PINK = 0x1A
+    LIGHT_CYAN = 0x1B
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build a NEC command."""
+        return NECCommand(
+            address=0xFF00,
+            command=self.value,
+            repeat_count=repeat_count,
+        )

--- a/infrared_protocols/codes/generic/led/generic_40_key.py
+++ b/infrared_protocols/codes/generic/led/generic_40_key.py
@@ -28,10 +28,10 @@ class Generic40KeyCode(IntEnum):
     SLOW = 0x0B
 
     JUMP3 = 0x0C
-    FADE3 = 0xDF
+    FADE3 = 0x0D
     JUMP7 = 0x0E
     FADE7 = 0x08
-    FLASH = 0x0B
+    FLASH = 0x09
     AUTO = 0x0A
 
     RED = 0x58


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Adds codes for generic 40-key remote to be used in LED Infrared integration
<img width="454" height="1000" alt="71mJ2d+ZtLL _AC_UF894,1000_QL80_FMwebp_" src="https://github.com/user-attachments/assets/680a91c7-8293-4d2d-805a-6b625816375e" />

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/176566<!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) -->

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
