### PR TITLE
fix: use correct codes for pre-2017 Edifier R1700BT

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -1,4 +1,8 @@
-"""Edifier speaker models, command-set groupings, and their mapping."""
+"""Edifier speaker models, command-set groupings, and their mapping.
+
+Mappings can also be found in
+https://support.edifier-online.com/hc/en-us/articles/4412111975059-Speaker-Remote-Control-Compatibility-List
+"""
 
 from enum import StrEnum
 
@@ -6,7 +10,8 @@ from enum import StrEnum
 class EdifierCommandSet(StrEnum):
     """Edifier command set groupings."""
 
-    R1700BT = "r1700bt"
+    R1700BT_PRE_2017 = "r1700bt_pre_2017"
+    R1700BTS = "r1700bts"
     R1280DB = "r1280db"
     R1280T = "r1280t"
     S360DB = "s360db"
@@ -17,8 +22,9 @@ class EdifierCommandSet(StrEnum):
 class EdifierModel(StrEnum):
     """Edifier speaker models."""
 
-    # R1700BT command set
-    R1700BT = "R1700BT"
+    # R1700BT (pre-2017) command set
+    R1700BT_PRE_2017 = "R1700BT (pre-2017)"
+    # R1700BTs command set
     R1700BTS = "R1700BTs"
     RC17A = "RC17A"
     RC80B = "RC80B"
@@ -40,12 +46,13 @@ class EdifierModel(StrEnum):
 
 
 MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
-    # R1700BT command set
-    EdifierModel.R1700BT: EdifierCommandSet.R1700BT,
-    EdifierModel.R1700BTS: EdifierCommandSet.R1700BT,
-    EdifierModel.RC17A: EdifierCommandSet.R1700BT,
-    EdifierModel.RC80B: EdifierCommandSet.R1700BT,
-    EdifierModel.R1855DB: EdifierCommandSet.R1700BT,
+    # R1700BT (pre-2017) command set
+    EdifierModel.R1700BT_PRE_2017: EdifierCommandSet.R1700BT_PRE_2017,
+    # R1700BTs command set
+    EdifierModel.R1700BTS: EdifierCommandSet.R1700BTS,
+    EdifierModel.RC17A: EdifierCommandSet.R1700BTS,
+    EdifierModel.RC80B: EdifierCommandSet.R1700BTS,
+    EdifierModel.R1855DB: EdifierCommandSet.R1700BTS,
     # R1280DB command set
     EdifierModel.R1280DB: EdifierCommandSet.R1280DB,
     EdifierModel.R2730DB: EdifierCommandSet.R1280DB,

--- a/infrared_protocols/codes/edifier/r1700bt_pre_2017.py
+++ b/infrared_protocols/codes/edifier/r1700bt_pre_2017.py
@@ -1,0 +1,30 @@
+"""Command codes for Edifier R1700BT (pre-2017) speakers.
+
+The R1700BT was sold in two hardware revisions with incompatible IR code
+sets:
+
+- Pre-2017 revision: RC10B remote (5 buttons, no power button). This
+  module covers its codes.
+- 2017 revision: RC10G remote (6 buttons, including power), which uses
+  the RC10D/R1280DB-family code values with a different function
+  mapping. Not covered by this module.
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class EdifierR1700BTPre2017Code(IntEnum):
+    """Edifier R1700BT (pre-2017) speaker IR command codes."""
+
+    VOLUME_UP = 0x2B
+    VOLUME_DOWN = 0x3C
+    MUTE = 0x1A
+    LINE = 0x5E
+    BLUETOOTH = 0x4D
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NECCommand."""
+        return NECCommand(address=0xE710, command=self.value, repeat_count=repeat_count)

--- a/infrared_protocols/codes/edifier/r1700bts.py
+++ b/infrared_protocols/codes/edifier/r1700bts.py
@@ -1,6 +1,6 @@
-"""Command codes for Edifier R1700BT speakers.
+"""Command codes for Edifier R1700BTs speakers.
 
-Shared command set used by R1700BT, R1700BTs, RC17A, RC80B, and R1855DB.
+Shared command set used by R1700BTs, RC17A, RC80B, and R1855DB.
 """
 
 from enum import IntEnum
@@ -9,8 +9,8 @@ from ...commands import Command
 from ...commands.nec import NECCommand
 
 
-class EdifierR1700BTCode(IntEnum):
-    """Edifier R1700BT speaker IR command codes."""
+class EdifierR1700BTsCode(IntEnum):
+    """Edifier R1700BTs speaker IR command codes."""
 
     POWER = 0x46
     VOLUME_UP = 0x06


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

The R1700BT was incorrectly grouped with R1700BTs, RC17A, RC80B, and R1855DB. Its actual remote (RC10B) uses a different code set. Move the shared family set to a new r1700bts module and add the correct codes as r1700bt_pre_2017, named after the hardware revision: the 2017 R1700BT revision ships with the RC10G remote (6 buttons, including power), and is not supported yet.

### BREAKING CHANGE
`EdifierR1700BTCode` is replaced by `EdifierR1700BTPre2017Code`. `EdifierModel.R1700BT` is renamed to `R1700BT_PRE_2017`, and `EdifierCommandSet.R1700BT` to `R1700BT_PRE_2017`.
R1700BTS, RC17A, RC80B, and R1855DB now map to `EdifierCommandSet.R1700BTS` backed by `EdifierR1700BTsCode` (same code values as before).


## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/176625

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
