### PR TITLE
Add fixed-code buttons for LG air conditioners

### DIFF
--- a/infrared_protocols/codes/lg/ac.py
+++ b/infrared_protocols/codes/lg/ac.py
@@ -1,0 +1,64 @@
+"""Fixed-code button codes for LG air conditioners.
+
+Each value is the 16-bit body of an LG2 frame the remote emits verbatim, unlike the
+state frames built by ``LgAcCommand``. The fixed 0x88 signature and the checksum nibble
+are the same for every frame, so they are not stored here; ``LgAcFixedCommand`` adds
+them. A full frame is ``0x88`` + the 16-bit value + a checksum nibble, e.g. the display
+toggle ``0xC00A`` is transmitted as ``0x88C00A6``.
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.lg_ac import LgAcFixedCommand
+
+
+class LgAcButton(IntEnum):
+    """LG AC fixed-code button; value is the 16-bit frame body."""
+
+    SWING_V_TOGGLE = 0x1000
+    """only flips between auto-swing and off; prefer SWING_V_SWING and SWING_V_OFF"""
+    JET = 0x100D
+    """Turbo mode; may be called VIRAAT or Power Cool on some remotes."""
+    DIET = 0x101F
+    """Reduces the unit's power draw"""
+
+    SWING_V_LOWEST = 0x1304
+    SWING_V_LOW = 0x1305
+    SWING_V_MIDDLE_LOW = 0x1306
+    SWING_V_MIDDLE_HIGH = 0x1307
+    SWING_V_HIGH = 0x1308
+    SWING_V_HIGHEST = 0x1309
+    SWING_H_LEFT = 0x130B
+    SWING_H_MIDDLE_LEFT = 0x130C
+    SWING_H_MIDDLE = 0x130D
+    SWING_H_MIDDLE_RIGHT = 0x130E
+    SWING_H_RIGHT = 0x130F
+    # Sweeps between the middle and one side, rather than resting at a position.
+    SWING_H_MIDDLE_TO_LEFT = 0x1310
+    SWING_H_MIDDLE_TO_RIGHT = 0x1311
+    # The swing (oscillate) and auto positions share one frame on this protocol.
+    SWING_V_SWING = 0x1314
+    SWING_V_OFF = 0x1315
+    SWING_H_SWING = 0x1316
+    SWING_H_OFF = 0x1317
+
+    AI_CONVERTIBLE = 0x1408
+
+    ION_GENERATOR_ON = 0xC000
+    ION_GENERATOR_OFF = 0xC008
+    LIGHT_TOGGLE = 0xC00A
+    AUTO_CLEAN_ON = 0xC00B
+    AUTO_CLEAN_OFF = 0xC00C
+    WIFI_TOGGLE = 0xC029
+    AUDIO_TOGGLE = 0xC075
+    # Caps the unit's power draw.
+    ENERGY_LIMIT_80 = 0xC07D
+    ENERGY_LIMIT_60 = 0xC07E
+    ENERGY_LIMIT_OFF = 0xC07F
+    ENERGY_LIMIT_40 = 0xC080
+    DIAGNOSE = 0xC0CE
+
+    def to_command(self) -> Command:
+        """Build an LG AC fixed-code command for this button."""
+        return LgAcFixedCommand(command=self.value)

--- a/infrared_protocols/codes/lg/ac.py
+++ b/infrared_protocols/codes/lg/ac.py
@@ -14,12 +14,17 @@ class LgACCode(IntEnum):
     """LG AC fixed-code button; value is the 16-bit frame body."""
 
     SWING_V_TOGGLE = 0x1000
-    """only flips between auto-swing and off; prefer SWING_V_SWING and SWING_V_OFF"""
+    """Flips between auto-swing and off only.
+
+    Prefer :attr:`SWING_V_SWING` and :attr:`SWING_V_OFF`.
+    """
     JET = 0x1008
     """Jet mode, the fast cool/heat boost."""
     VIRAAT = 0x100D
     """Viraat mode, an additional separate boost offered on LG India units.
-    Distinct from JET."""
+
+    Distinct from :attr:`JET`.
+    """
     ECO = 0x101F
     """Reduces the unit's power draw; may be called DIET on some remotes."""
 

--- a/infrared_protocols/codes/lg/ac.py
+++ b/infrared_protocols/codes/lg/ac.py
@@ -10,7 +10,7 @@ from ...commands import Command
 from ...commands.lg_ac import LgAcFixedCommand
 
 
-class LgACCode(IntEnum):
+class LGACCode(IntEnum):
     """LG AC fixed-code button; value is the 16-bit frame body."""
 
     SWING_V_TOGGLE = 0x1000

--- a/infrared_protocols/codes/lg/ac.py
+++ b/infrared_protocols/codes/lg/ac.py
@@ -1,10 +1,7 @@
 """Fixed-code button codes for LG air conditioners.
 
 Each value is the 16-bit body of an LG2 frame the remote emits verbatim, unlike the
-state frames built by ``LgAcCommand``. The fixed 0x88 signature and the checksum nibble
-are the same for every frame, so they are not stored here; ``LgAcFixedCommand`` adds
-them. A full frame is ``0x88`` + the 16-bit value + a checksum nibble, e.g. the display
-toggle ``0xC00A`` is transmitted as ``0x88C00A6``.
+state frames built by ``LgAcCommand``.
 """
 
 from enum import IntEnum
@@ -13,15 +10,18 @@ from ...commands import Command
 from ...commands.lg_ac import LgAcFixedCommand
 
 
-class LgAcButton(IntEnum):
+class LgACCode(IntEnum):
     """LG AC fixed-code button; value is the 16-bit frame body."""
 
     SWING_V_TOGGLE = 0x1000
     """only flips between auto-swing and off; prefer SWING_V_SWING and SWING_V_OFF"""
-    JET = 0x100D
-    """Turbo mode; may be called VIRAAT or Power Cool on some remotes."""
-    DIET = 0x101F
-    """Reduces the unit's power draw"""
+    JET = 0x1008
+    """Jet mode, the fast cool/heat boost."""
+    VIRAAT = 0x100D
+    """Viraat mode, an additional separate boost offered on LG India units.
+    Distinct from JET."""
+    ECO = 0x101F
+    """Reduces the unit's power draw; may be called DIET on some remotes."""
 
     SWING_V_LOWEST = 0x1304
     SWING_V_LOW = 0x1305
@@ -61,4 +61,4 @@ class LgAcButton(IntEnum):
 
     def to_command(self) -> Command:
         """Build an LG AC fixed-code command for this button."""
-        return LgAcFixedCommand(command=self.value)
+        return LgAcFixedCommand(code=self.value)

--- a/infrared_protocols/commands/lg_ac.py
+++ b/infrared_protocols/commands/lg_ac.py
@@ -121,6 +121,39 @@ def _encode_frame(frame: int) -> list[int]:
     return timings
 
 
+def _decode_frame(timings: list[int]) -> int | None:
+    """Decode raw IR timings into a validated 28-bit LG frame."""
+    # Header pair (2) + 28 bit pairs (56) + the trailing mark (1)
+    if len(timings) < 2 + 2 * _BITS + 1:
+        return None
+
+    hdr_mark = timings[0]
+    hdr_space = abs(timings[1])
+    if not (
+        _matches_header(hdr_mark, hdr_space, _HDR_MARK, _HDR_SPACE)
+        or _matches_header(hdr_mark, hdr_space, _ALT_HDR_MARK, _ALT_HDR_SPACE)
+    ):
+        return None
+
+    frame = 0
+    for i in range(2, 2 + 2 * _BITS, 2):
+        bit = _decode_bit(timings[i], abs(timings[i + 1]))
+        if bit is None:
+            return None
+        frame = (frame << 1) | bit
+
+    if abs(timings[2 + 2 * _BITS] - _BIT_MARK) > _BIT_TOLERANCE:
+        return None
+
+    if frame >> 20 != _SIGNATURE:
+        return None
+
+    if _checksum(frame) != frame & 0xF:
+        return None
+
+    return frame
+
+
 class LgAcCommand(Command):
     """LG air-conditioner IR command.
 
@@ -187,32 +220,8 @@ class LgAcCommand(Command):
 
         Returns an LgAcCommand if the timings match, or None otherwise.
         """
-        # Header pair (2) + 28 bit pairs (56) + the trailing mark (1)
-        if len(timings) < 2 + 2 * _BITS + 1:
-            return None
-
-        hdr_mark = timings[0]
-        hdr_space = abs(timings[1])
-        if not (
-            _matches_header(hdr_mark, hdr_space, _HDR_MARK, _HDR_SPACE)
-            or _matches_header(hdr_mark, hdr_space, _ALT_HDR_MARK, _ALT_HDR_SPACE)
-        ):
-            return None
-
-        frame = 0
-        for i in range(2, 2 + 2 * _BITS, 2):
-            bit = _decode_bit(timings[i], abs(timings[i + 1]))
-            if bit is None:
-                return None
-            frame = (frame << 1) | bit
-
-        if abs(timings[2 + 2 * _BITS] - _BIT_MARK) > _BIT_TOLERANCE:
-            return None
-
-        if frame >> 20 != _SIGNATURE:
-            return None
-
-        if _checksum(frame) != frame & 0xF:
+        frame = _decode_frame(timings)
+        if frame is None:
             return None
 
         if frame == _OFF_FRAME:
@@ -237,3 +246,39 @@ class LgAcCommand(Command):
                 return None
 
         return cls(mode=mode, temperature=temperature, fan=fan)
+
+
+class LgAcFixedCommand(Command):
+    """LG air-conditioner fixed-code command.
+
+    Some remote buttons emit a whole frame verbatim rather than a state frame.
+    ``command`` is the 16-bit body between the fixed 0x88 signature and the checksum
+    nibble.
+    """
+
+    command: int
+
+    def __init__(self, *, command: int, modulation: int = 38000) -> None:
+        """Initialize the LG AC fixed-code command."""
+        super().__init__(modulation=modulation)
+        if not 0 <= command <= 0xFFFF:
+            raise ValueError(f"command must be a 16-bit value, got {command:#x}")
+        self.command = command
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the fixed-code command."""
+        frame_data = _BASE | (self.command << 4)
+        return _encode_frame(frame_data | _checksum(frame_data))
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into an LgAcFixedCommand.
+
+        Returns any valid LG frame as its 16-bit body. A state frame decodes here too;
+        use ``LgAcCommand`` to read one as a mode, temperature and fan instead.
+        """
+        frame = _decode_frame(timings)
+        if frame is None:
+            return None
+        return cls(command=(frame >> 4) & 0xFFFF)

--- a/infrared_protocols/commands/lg_ac.py
+++ b/infrared_protocols/commands/lg_ac.py
@@ -251,24 +251,29 @@ class LgAcCommand(Command):
 class LgAcFixedCommand(Command):
     """LG air-conditioner fixed-code command.
 
-    Some remote buttons emit a whole frame verbatim rather than a state frame.
-    ``command`` is the 16-bit body between the fixed 0x88 signature and the checksum
-    nibble.
+    Some remote buttons emit a whole frame verbatim rather than a state frame, so the
+    nibbles that carry temperature and fan in a state frame are part of the code itself.
+
+    ``code`` is the 16-bit body between the fixed 0x88 signature and the checksum
+    nibble; both are the same for every frame and are derived here rather than stored.
+    A full frame is ``0x88`` + the 16-bit body + a checksum nibble, e.g. the display
+    toggle ``0xC00A`` is transmitted as ``0x88C00A6``. See ``LgACCode`` for the known
+    bodies.
     """
 
-    command: int
+    code: int
 
-    def __init__(self, *, command: int, modulation: int = 38000) -> None:
+    def __init__(self, *, code: int, modulation: int = 38000) -> None:
         """Initialize the LG AC fixed-code command."""
         super().__init__(modulation=modulation)
-        if not 0 <= command <= 0xFFFF:
-            raise ValueError(f"command must be a 16-bit value, got {command:#x}")
-        self.command = command
+        if not 0 <= code <= 0xFFFF:
+            raise ValueError(f"code must be a 16-bit value, got {code:#x}")
+        self.code = code
 
     @override
     def get_raw_timings(self) -> list[int]:
         """Get raw timings for the fixed-code command."""
-        frame_data = _BASE | (self.command << 4)
+        frame_data = _BASE | (self.code << 4)
         return _encode_frame(frame_data | _checksum(frame_data))
 
     @classmethod
@@ -281,4 +286,4 @@ class LgAcFixedCommand(Command):
         frame = _decode_frame(timings)
         if frame is None:
             return None
-        return cls(command=(frame >> 4) & 0xFFFF)
+        return cls(code=(frame >> 4) & 0xFFFF)

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -2,9 +2,11 @@
 
 import pytest
 
+from infrared_protocols.codes.lg.ac import LgAcButton
 from infrared_protocols.commands.lg_ac import (
     LgAcCommand,
     LgAcFanSpeed,
+    LgAcFixedCommand,
     LgAcMode,
 )
 
@@ -312,3 +314,105 @@ def test_decode_returns_none_for_out_of_tolerance_bit() -> None:
 def test_decode_returns_none_for_invalid_frame(frame: int) -> None:
     """from_raw_timings must reject frames that fail validation."""
     assert LgAcCommand.from_raw_timings(_build_timings(frame)) is None
+
+
+# The full 28-bit frame each button transmits, from the captures and IRremoteESP8266's
+# ir_LG.h. Pins every button to its documented code and guards the 16-bit bodies against
+# a typo, since the encoder derives the signature and checksum and cannot reveal one.
+_BUTTON_FRAMES: dict[LgAcButton, int] = {
+    LgAcButton.ION_GENERATOR_ON: 0x88C000C,
+    LgAcButton.ION_GENERATOR_OFF: 0x88C0084,
+    LgAcButton.LIGHT_TOGGLE: 0x88C00A6,
+    LgAcButton.AUTO_CLEAN_ON: 0x88C00B7,
+    LgAcButton.AUTO_CLEAN_OFF: 0x88C00C8,
+    LgAcButton.WIFI_TOGGLE: 0x88C0297,
+    LgAcButton.AUDIO_TOGGLE: 0x88C0758,
+    LgAcButton.ENERGY_LIMIT_80: 0x88C07D0,
+    LgAcButton.ENERGY_LIMIT_60: 0x88C07E1,
+    LgAcButton.ENERGY_LIMIT_OFF: 0x88C07F2,
+    LgAcButton.ENERGY_LIMIT_40: 0x88C0804,
+    LgAcButton.DIAGNOSE: 0x88C0CE6,
+    LgAcButton.JET: 0x88100DE,
+    LgAcButton.DIET: 0x88101F1,
+    LgAcButton.AI_CONVERTIBLE: 0x881408D,
+    LgAcButton.SWING_V_TOGGLE: 0x8810001,
+    LgAcButton.SWING_V_LOWEST: 0x8813048,
+    LgAcButton.SWING_V_LOW: 0x8813059,
+    LgAcButton.SWING_V_MIDDLE_LOW: 0x881306A,
+    LgAcButton.SWING_V_MIDDLE_HIGH: 0x881307B,
+    LgAcButton.SWING_V_HIGH: 0x881308C,
+    LgAcButton.SWING_V_HIGHEST: 0x881309D,
+    LgAcButton.SWING_V_SWING: 0x8813149,
+    LgAcButton.SWING_V_OFF: 0x881315A,
+    LgAcButton.SWING_H_LEFT: 0x88130BF,
+    LgAcButton.SWING_H_MIDDLE_LEFT: 0x88130C0,
+    LgAcButton.SWING_H_MIDDLE: 0x88130D1,
+    LgAcButton.SWING_H_MIDDLE_RIGHT: 0x88130E2,
+    LgAcButton.SWING_H_RIGHT: 0x88130F3,
+    LgAcButton.SWING_H_MIDDLE_TO_LEFT: 0x8813105,
+    LgAcButton.SWING_H_MIDDLE_TO_RIGHT: 0x8813116,
+    LgAcButton.SWING_H_SWING: 0x881316B,
+    LgAcButton.SWING_H_OFF: 0x881317C,
+}
+
+
+def test_button_frame_table_covers_every_button() -> None:
+    """The expected-frame table must list every button, so parametrization is total."""
+    assert set(_BUTTON_FRAMES) == set(LgAcButton)
+
+
+def test_fixed_command_encodes_signature_and_checksum() -> None:
+    """A fixed-code command wraps its body in the LG2 header, signature and checksum."""
+    timings = LgAcFixedCommand(command=LgAcButton.LIGHT_TOGGLE).get_raw_timings()
+
+    assert timings[:2] == [3200, -9900]
+    assert len(timings) == 2 + 2 * _BITS + 1
+    assert _extract_frame(timings) == _BUTTON_FRAMES[LgAcButton.LIGHT_TOGGLE]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(1 << 16, id="too_wide"),
+        pytest.param(-1, id="negative"),
+    ],
+)
+def test_fixed_command_rejects_out_of_range_command(command: int) -> None:
+    """A command body outside 16 bits must raise."""
+    with pytest.raises(ValueError, match="16-bit value"):
+        LgAcFixedCommand(command=command)
+
+
+def test_fixed_command_default_modulation() -> None:
+    """Default modulation must be 38 kHz."""
+    cmd = LgAcFixedCommand(command=LgAcButton.JET)
+    assert cmd.modulation == 38000
+    assert cmd.repeat_count == 0
+
+
+@pytest.mark.parametrize("button", list(LgAcButton), ids=lambda b: b.name)
+def test_button_to_command_encodes_expected_frame(button: LgAcButton) -> None:
+    """Each button must encode to its documented full frame."""
+    assert (
+        _extract_frame(button.to_command().get_raw_timings()) == _BUTTON_FRAMES[button]
+    )
+
+
+@pytest.mark.parametrize("button", list(LgAcButton), ids=lambda b: b.name)
+def test_fixed_command_roundtrip(button: LgAcButton) -> None:
+    """Encoding then decoding a button must recover its body."""
+    decoded = LgAcFixedCommand.from_raw_timings(button.to_command().get_raw_timings())
+    assert decoded is not None
+    assert decoded.command == button.value
+
+
+def test_fixed_command_decodes_captured_frame() -> None:
+    """A captured full frame must decode to the matching button body."""
+    decoded = LgAcFixedCommand.from_raw_timings(_build_timings(0x88C00A6))
+    assert decoded is not None
+    assert decoded.command == LgAcButton.LIGHT_TOGGLE
+
+
+def test_fixed_command_from_raw_timings_rejects_bad_checksum() -> None:
+    """A frame whose checksum nibble is wrong must not decode."""
+    assert LgAcFixedCommand.from_raw_timings(_build_timings(0x8800001)) is None

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from infrared_protocols.codes.lg.ac import LgACCode
+from infrared_protocols.codes.lg.ac import LGACCode
 from infrared_protocols.commands.lg_ac import (
     LgAcCommand,
     LgAcFanSpeed,
@@ -319,56 +319,56 @@ def test_decode_returns_none_for_invalid_frame(frame: int) -> None:
 # The full 28-bit frame each code transmits, from the captures and IRremoteESP8266's
 # ir_LG.h. Pins every button to its documented code and guards the 16-bit bodies against
 # a typo, since the encoder derives the signature and checksum and cannot reveal one.
-_CODE_FRAMES: dict[LgACCode, int] = {
-    LgACCode.ION_GENERATOR_ON: 0x88C000C,
-    LgACCode.ION_GENERATOR_OFF: 0x88C0084,
-    LgACCode.LIGHT_TOGGLE: 0x88C00A6,
-    LgACCode.AUTO_CLEAN_ON: 0x88C00B7,
-    LgACCode.AUTO_CLEAN_OFF: 0x88C00C8,
-    LgACCode.WIFI_TOGGLE: 0x88C0297,
-    LgACCode.AUDIO_TOGGLE: 0x88C0758,
-    LgACCode.ENERGY_LIMIT_80: 0x88C07D0,
-    LgACCode.ENERGY_LIMIT_60: 0x88C07E1,
-    LgACCode.ENERGY_LIMIT_OFF: 0x88C07F2,
-    LgACCode.ENERGY_LIMIT_40: 0x88C0804,
-    LgACCode.DIAGNOSE: 0x88C0CE6,
-    LgACCode.JET: 0x8810089,
-    LgACCode.VIRAAT: 0x88100DE,
-    LgACCode.ECO: 0x88101F1,
-    LgACCode.AI_CONVERTIBLE: 0x881408D,
-    LgACCode.SWING_V_TOGGLE: 0x8810001,
-    LgACCode.SWING_V_LOWEST: 0x8813048,
-    LgACCode.SWING_V_LOW: 0x8813059,
-    LgACCode.SWING_V_MIDDLE_LOW: 0x881306A,
-    LgACCode.SWING_V_MIDDLE_HIGH: 0x881307B,
-    LgACCode.SWING_V_HIGH: 0x881308C,
-    LgACCode.SWING_V_HIGHEST: 0x881309D,
-    LgACCode.SWING_V_SWING: 0x8813149,
-    LgACCode.SWING_V_OFF: 0x881315A,
-    LgACCode.SWING_H_LEFT: 0x88130BF,
-    LgACCode.SWING_H_MIDDLE_LEFT: 0x88130C0,
-    LgACCode.SWING_H_MIDDLE: 0x88130D1,
-    LgACCode.SWING_H_MIDDLE_RIGHT: 0x88130E2,
-    LgACCode.SWING_H_RIGHT: 0x88130F3,
-    LgACCode.SWING_H_MIDDLE_TO_LEFT: 0x8813105,
-    LgACCode.SWING_H_MIDDLE_TO_RIGHT: 0x8813116,
-    LgACCode.SWING_H_SWING: 0x881316B,
-    LgACCode.SWING_H_OFF: 0x881317C,
+_CODE_FRAMES: dict[LGACCode, int] = {
+    LGACCode.ION_GENERATOR_ON: 0x88C000C,
+    LGACCode.ION_GENERATOR_OFF: 0x88C0084,
+    LGACCode.LIGHT_TOGGLE: 0x88C00A6,
+    LGACCode.AUTO_CLEAN_ON: 0x88C00B7,
+    LGACCode.AUTO_CLEAN_OFF: 0x88C00C8,
+    LGACCode.WIFI_TOGGLE: 0x88C0297,
+    LGACCode.AUDIO_TOGGLE: 0x88C0758,
+    LGACCode.ENERGY_LIMIT_80: 0x88C07D0,
+    LGACCode.ENERGY_LIMIT_60: 0x88C07E1,
+    LGACCode.ENERGY_LIMIT_OFF: 0x88C07F2,
+    LGACCode.ENERGY_LIMIT_40: 0x88C0804,
+    LGACCode.DIAGNOSE: 0x88C0CE6,
+    LGACCode.JET: 0x8810089,
+    LGACCode.VIRAAT: 0x88100DE,
+    LGACCode.ECO: 0x88101F1,
+    LGACCode.AI_CONVERTIBLE: 0x881408D,
+    LGACCode.SWING_V_TOGGLE: 0x8810001,
+    LGACCode.SWING_V_LOWEST: 0x8813048,
+    LGACCode.SWING_V_LOW: 0x8813059,
+    LGACCode.SWING_V_MIDDLE_LOW: 0x881306A,
+    LGACCode.SWING_V_MIDDLE_HIGH: 0x881307B,
+    LGACCode.SWING_V_HIGH: 0x881308C,
+    LGACCode.SWING_V_HIGHEST: 0x881309D,
+    LGACCode.SWING_V_SWING: 0x8813149,
+    LGACCode.SWING_V_OFF: 0x881315A,
+    LGACCode.SWING_H_LEFT: 0x88130BF,
+    LGACCode.SWING_H_MIDDLE_LEFT: 0x88130C0,
+    LGACCode.SWING_H_MIDDLE: 0x88130D1,
+    LGACCode.SWING_H_MIDDLE_RIGHT: 0x88130E2,
+    LGACCode.SWING_H_RIGHT: 0x88130F3,
+    LGACCode.SWING_H_MIDDLE_TO_LEFT: 0x8813105,
+    LGACCode.SWING_H_MIDDLE_TO_RIGHT: 0x8813116,
+    LGACCode.SWING_H_SWING: 0x881316B,
+    LGACCode.SWING_H_OFF: 0x881317C,
 }
 
 
 def test_code_frame_table_covers_every_code() -> None:
     """The expected-frame table must list every code, so parametrization is total."""
-    assert set(_CODE_FRAMES) == set(LgACCode)
+    assert set(_CODE_FRAMES) == set(LGACCode)
 
 
 def test_fixed_command_encodes_signature_and_checksum() -> None:
     """A fixed-code command wraps its body in the LG2 header, signature and checksum."""
-    timings = LgAcFixedCommand(code=LgACCode.LIGHT_TOGGLE).get_raw_timings()
+    timings = LgAcFixedCommand(code=LGACCode.LIGHT_TOGGLE).get_raw_timings()
 
     assert timings[:2] == [3200, -9900]
     assert len(timings) == 2 + 2 * _BITS + 1
-    assert _extract_frame(timings) == _CODE_FRAMES[LgACCode.LIGHT_TOGGLE]
+    assert _extract_frame(timings) == _CODE_FRAMES[LGACCode.LIGHT_TOGGLE]
 
 
 @pytest.mark.parametrize(
@@ -386,19 +386,19 @@ def test_fixed_command_rejects_out_of_range_code(code: int) -> None:
 
 def test_fixed_command_default_modulation() -> None:
     """Default modulation must be 38 kHz."""
-    cmd = LgAcFixedCommand(code=LgACCode.JET)
+    cmd = LgAcFixedCommand(code=LGACCode.JET)
     assert cmd.modulation == 38000
     assert cmd.repeat_count == 0
 
 
-@pytest.mark.parametrize("code", list(LgACCode), ids=lambda c: c.name)
-def test_code_to_command_encodes_expected_frame(code: LgACCode) -> None:
+@pytest.mark.parametrize("code", list(LGACCode), ids=lambda c: c.name)
+def test_code_to_command_encodes_expected_frame(code: LGACCode) -> None:
     """Each code must encode to its documented full frame."""
     assert _extract_frame(code.to_command().get_raw_timings()) == _CODE_FRAMES[code]
 
 
-@pytest.mark.parametrize("code", list(LgACCode), ids=lambda c: c.name)
-def test_fixed_command_roundtrip(code: LgACCode) -> None:
+@pytest.mark.parametrize("code", list(LGACCode), ids=lambda c: c.name)
+def test_fixed_command_roundtrip(code: LGACCode) -> None:
     """Encoding then decoding a code must recover its body."""
     decoded = LgAcFixedCommand.from_raw_timings(code.to_command().get_raw_timings())
     assert decoded is not None
@@ -409,7 +409,7 @@ def test_fixed_command_decodes_captured_frame() -> None:
     """A captured full frame must decode to the matching code body."""
     decoded = LgAcFixedCommand.from_raw_timings(_build_timings(0x88C00A6))
     assert decoded is not None
-    assert decoded.code == LgACCode.LIGHT_TOGGLE
+    assert decoded.code == LGACCode.LIGHT_TOGGLE
 
 
 def test_fixed_command_from_raw_timings_rejects_bad_checksum() -> None:
@@ -417,8 +417,8 @@ def test_fixed_command_from_raw_timings_rejects_bad_checksum() -> None:
     assert LgAcFixedCommand.from_raw_timings(_build_timings(0x8800001)) is None
 
 
-@pytest.mark.parametrize("code", list(LgACCode), ids=lambda c: c.name)
-def test_state_decoder_rejects_every_fixed_code(code: LgACCode) -> None:
+@pytest.mark.parametrize("code", list(LGACCode), ids=lambda c: c.name)
+def test_state_decoder_rejects_every_fixed_code(code: LGACCode) -> None:
     """A fixed-code frame carries no state, so LgAcCommand must not decode one."""
     timings = code.to_command().get_raw_timings()
     assert LgAcCommand.from_raw_timings(timings) is None

--- a/tests/commands/test_lg_ac.py
+++ b/tests/commands/test_lg_ac.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from infrared_protocols.codes.lg.ac import LgAcButton
+from infrared_protocols.codes.lg.ac import LgACCode
 from infrared_protocols.commands.lg_ac import (
     LgAcCommand,
     LgAcFanSpeed,
@@ -316,103 +316,109 @@ def test_decode_returns_none_for_invalid_frame(frame: int) -> None:
     assert LgAcCommand.from_raw_timings(_build_timings(frame)) is None
 
 
-# The full 28-bit frame each button transmits, from the captures and IRremoteESP8266's
+# The full 28-bit frame each code transmits, from the captures and IRremoteESP8266's
 # ir_LG.h. Pins every button to its documented code and guards the 16-bit bodies against
 # a typo, since the encoder derives the signature and checksum and cannot reveal one.
-_BUTTON_FRAMES: dict[LgAcButton, int] = {
-    LgAcButton.ION_GENERATOR_ON: 0x88C000C,
-    LgAcButton.ION_GENERATOR_OFF: 0x88C0084,
-    LgAcButton.LIGHT_TOGGLE: 0x88C00A6,
-    LgAcButton.AUTO_CLEAN_ON: 0x88C00B7,
-    LgAcButton.AUTO_CLEAN_OFF: 0x88C00C8,
-    LgAcButton.WIFI_TOGGLE: 0x88C0297,
-    LgAcButton.AUDIO_TOGGLE: 0x88C0758,
-    LgAcButton.ENERGY_LIMIT_80: 0x88C07D0,
-    LgAcButton.ENERGY_LIMIT_60: 0x88C07E1,
-    LgAcButton.ENERGY_LIMIT_OFF: 0x88C07F2,
-    LgAcButton.ENERGY_LIMIT_40: 0x88C0804,
-    LgAcButton.DIAGNOSE: 0x88C0CE6,
-    LgAcButton.JET: 0x88100DE,
-    LgAcButton.DIET: 0x88101F1,
-    LgAcButton.AI_CONVERTIBLE: 0x881408D,
-    LgAcButton.SWING_V_TOGGLE: 0x8810001,
-    LgAcButton.SWING_V_LOWEST: 0x8813048,
-    LgAcButton.SWING_V_LOW: 0x8813059,
-    LgAcButton.SWING_V_MIDDLE_LOW: 0x881306A,
-    LgAcButton.SWING_V_MIDDLE_HIGH: 0x881307B,
-    LgAcButton.SWING_V_HIGH: 0x881308C,
-    LgAcButton.SWING_V_HIGHEST: 0x881309D,
-    LgAcButton.SWING_V_SWING: 0x8813149,
-    LgAcButton.SWING_V_OFF: 0x881315A,
-    LgAcButton.SWING_H_LEFT: 0x88130BF,
-    LgAcButton.SWING_H_MIDDLE_LEFT: 0x88130C0,
-    LgAcButton.SWING_H_MIDDLE: 0x88130D1,
-    LgAcButton.SWING_H_MIDDLE_RIGHT: 0x88130E2,
-    LgAcButton.SWING_H_RIGHT: 0x88130F3,
-    LgAcButton.SWING_H_MIDDLE_TO_LEFT: 0x8813105,
-    LgAcButton.SWING_H_MIDDLE_TO_RIGHT: 0x8813116,
-    LgAcButton.SWING_H_SWING: 0x881316B,
-    LgAcButton.SWING_H_OFF: 0x881317C,
+_CODE_FRAMES: dict[LgACCode, int] = {
+    LgACCode.ION_GENERATOR_ON: 0x88C000C,
+    LgACCode.ION_GENERATOR_OFF: 0x88C0084,
+    LgACCode.LIGHT_TOGGLE: 0x88C00A6,
+    LgACCode.AUTO_CLEAN_ON: 0x88C00B7,
+    LgACCode.AUTO_CLEAN_OFF: 0x88C00C8,
+    LgACCode.WIFI_TOGGLE: 0x88C0297,
+    LgACCode.AUDIO_TOGGLE: 0x88C0758,
+    LgACCode.ENERGY_LIMIT_80: 0x88C07D0,
+    LgACCode.ENERGY_LIMIT_60: 0x88C07E1,
+    LgACCode.ENERGY_LIMIT_OFF: 0x88C07F2,
+    LgACCode.ENERGY_LIMIT_40: 0x88C0804,
+    LgACCode.DIAGNOSE: 0x88C0CE6,
+    LgACCode.JET: 0x8810089,
+    LgACCode.VIRAAT: 0x88100DE,
+    LgACCode.ECO: 0x88101F1,
+    LgACCode.AI_CONVERTIBLE: 0x881408D,
+    LgACCode.SWING_V_TOGGLE: 0x8810001,
+    LgACCode.SWING_V_LOWEST: 0x8813048,
+    LgACCode.SWING_V_LOW: 0x8813059,
+    LgACCode.SWING_V_MIDDLE_LOW: 0x881306A,
+    LgACCode.SWING_V_MIDDLE_HIGH: 0x881307B,
+    LgACCode.SWING_V_HIGH: 0x881308C,
+    LgACCode.SWING_V_HIGHEST: 0x881309D,
+    LgACCode.SWING_V_SWING: 0x8813149,
+    LgACCode.SWING_V_OFF: 0x881315A,
+    LgACCode.SWING_H_LEFT: 0x88130BF,
+    LgACCode.SWING_H_MIDDLE_LEFT: 0x88130C0,
+    LgACCode.SWING_H_MIDDLE: 0x88130D1,
+    LgACCode.SWING_H_MIDDLE_RIGHT: 0x88130E2,
+    LgACCode.SWING_H_RIGHT: 0x88130F3,
+    LgACCode.SWING_H_MIDDLE_TO_LEFT: 0x8813105,
+    LgACCode.SWING_H_MIDDLE_TO_RIGHT: 0x8813116,
+    LgACCode.SWING_H_SWING: 0x881316B,
+    LgACCode.SWING_H_OFF: 0x881317C,
 }
 
 
-def test_button_frame_table_covers_every_button() -> None:
-    """The expected-frame table must list every button, so parametrization is total."""
-    assert set(_BUTTON_FRAMES) == set(LgAcButton)
+def test_code_frame_table_covers_every_code() -> None:
+    """The expected-frame table must list every code, so parametrization is total."""
+    assert set(_CODE_FRAMES) == set(LgACCode)
 
 
 def test_fixed_command_encodes_signature_and_checksum() -> None:
     """A fixed-code command wraps its body in the LG2 header, signature and checksum."""
-    timings = LgAcFixedCommand(command=LgAcButton.LIGHT_TOGGLE).get_raw_timings()
+    timings = LgAcFixedCommand(code=LgACCode.LIGHT_TOGGLE).get_raw_timings()
 
     assert timings[:2] == [3200, -9900]
     assert len(timings) == 2 + 2 * _BITS + 1
-    assert _extract_frame(timings) == _BUTTON_FRAMES[LgAcButton.LIGHT_TOGGLE]
+    assert _extract_frame(timings) == _CODE_FRAMES[LgACCode.LIGHT_TOGGLE]
 
 
 @pytest.mark.parametrize(
-    "command",
+    "code",
     [
         pytest.param(1 << 16, id="too_wide"),
         pytest.param(-1, id="negative"),
     ],
 )
-def test_fixed_command_rejects_out_of_range_command(command: int) -> None:
-    """A command body outside 16 bits must raise."""
+def test_fixed_command_rejects_out_of_range_code(code: int) -> None:
+    """A code body outside 16 bits must raise."""
     with pytest.raises(ValueError, match="16-bit value"):
-        LgAcFixedCommand(command=command)
+        LgAcFixedCommand(code=code)
 
 
 def test_fixed_command_default_modulation() -> None:
     """Default modulation must be 38 kHz."""
-    cmd = LgAcFixedCommand(command=LgAcButton.JET)
+    cmd = LgAcFixedCommand(code=LgACCode.JET)
     assert cmd.modulation == 38000
     assert cmd.repeat_count == 0
 
 
-@pytest.mark.parametrize("button", list(LgAcButton), ids=lambda b: b.name)
-def test_button_to_command_encodes_expected_frame(button: LgAcButton) -> None:
-    """Each button must encode to its documented full frame."""
-    assert (
-        _extract_frame(button.to_command().get_raw_timings()) == _BUTTON_FRAMES[button]
-    )
+@pytest.mark.parametrize("code", list(LgACCode), ids=lambda c: c.name)
+def test_code_to_command_encodes_expected_frame(code: LgACCode) -> None:
+    """Each code must encode to its documented full frame."""
+    assert _extract_frame(code.to_command().get_raw_timings()) == _CODE_FRAMES[code]
 
 
-@pytest.mark.parametrize("button", list(LgAcButton), ids=lambda b: b.name)
-def test_fixed_command_roundtrip(button: LgAcButton) -> None:
-    """Encoding then decoding a button must recover its body."""
-    decoded = LgAcFixedCommand.from_raw_timings(button.to_command().get_raw_timings())
+@pytest.mark.parametrize("code", list(LgACCode), ids=lambda c: c.name)
+def test_fixed_command_roundtrip(code: LgACCode) -> None:
+    """Encoding then decoding a code must recover its body."""
+    decoded = LgAcFixedCommand.from_raw_timings(code.to_command().get_raw_timings())
     assert decoded is not None
-    assert decoded.command == button.value
+    assert decoded.code == code.value
 
 
 def test_fixed_command_decodes_captured_frame() -> None:
-    """A captured full frame must decode to the matching button body."""
+    """A captured full frame must decode to the matching code body."""
     decoded = LgAcFixedCommand.from_raw_timings(_build_timings(0x88C00A6))
     assert decoded is not None
-    assert decoded.command == LgAcButton.LIGHT_TOGGLE
+    assert decoded.code == LgACCode.LIGHT_TOGGLE
 
 
 def test_fixed_command_from_raw_timings_rejects_bad_checksum() -> None:
     """A frame whose checksum nibble is wrong must not decode."""
     assert LgAcFixedCommand.from_raw_timings(_build_timings(0x8800001)) is None
+
+
+@pytest.mark.parametrize("code", list(LgACCode), ids=lambda c: c.name)
+def test_state_decoder_rejects_every_fixed_code(code: LgACCode) -> None:
+    """A fixed-code frame carries no state, so LgAcCommand must not decode one."""
+    timings = code.to_command().get_raw_timings()
+    assert LgAcCommand.from_raw_timings(timings) is None


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

Fixed codes for LG AC

## Additional information

~TBA, once https://github.com/home-assistant/core/pull/174142 is merged~

- Link to core pull request: https://github.com/home-assistant/core/pull/177191

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
