### PR TITLE
feat: add Edifier R1700BT (2017) command set

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -11,6 +11,7 @@ class EdifierCommandSet(StrEnum):
     """Edifier command set groupings."""
 
     R1700BT_PRE_2017 = "r1700bt_pre_2017"
+    R1700BT_2017 = "r1700bt_2017"
     R1700BTS = "r1700bts"
     R1280DB = "r1280db"
     R1280T = "r1280t"
@@ -24,6 +25,8 @@ class EdifierModel(StrEnum):
 
     # R1700BT (pre-2017) command set
     R1700BT_PRE_2017 = "R1700BT (pre-2017)"
+    # R1700BT (2017) command set
+    R1700BT_2017 = "R1700BT (2017)"
     # R1700BTs command set
     R1700BTS = "R1700BTs"
     RC17A = "RC17A"
@@ -48,6 +51,8 @@ class EdifierModel(StrEnum):
 MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
     # R1700BT (pre-2017) command set
     EdifierModel.R1700BT_PRE_2017: EdifierCommandSet.R1700BT_PRE_2017,
+    # R1700BT (2017) command set
+    EdifierModel.R1700BT_2017: EdifierCommandSet.R1700BT_2017,
     # R1700BTs command set
     EdifierModel.R1700BTS: EdifierCommandSet.R1700BTS,
     EdifierModel.RC17A: EdifierCommandSet.R1700BTS,

--- a/infrared_protocols/codes/edifier/r1700bt_2017.py
+++ b/infrared_protocols/codes/edifier/r1700bt_2017.py
@@ -1,0 +1,24 @@
+"""Command codes for Edifier R1700BT (2017) speakers.
+
+The 2017 revision of the R1700BT uses the RC10G remote (6 buttons, including power).
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class EdifierR1700BT2017Code(IntEnum):
+    """Edifier R1700BT (2017) speaker IR command codes."""
+
+    POWER = 0x01
+    VOLUME_UP = 0x09
+    VOLUME_DOWN = 0x0C
+    MUTE = 0x00
+    BLUETOOTH = 0x0A
+    LINE = 0x15
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NECCommand."""
+        return NECCommand(address=0xE710, command=self.value, repeat_count=repeat_count)

--- a/infrared_protocols/codes/edifier/r1700bt_pre_2017.py
+++ b/infrared_protocols/codes/edifier/r1700bt_pre_2017.py
@@ -1,13 +1,6 @@
 """Command codes for Edifier R1700BT (pre-2017) speakers.
 
-The R1700BT was sold in two hardware revisions with incompatible IR code
-sets:
-
-- Pre-2017 revision: RC10B remote (5 buttons, no power button). This
-  module covers its codes.
-- 2017 revision: RC10G remote (6 buttons, including power), which uses
-  the RC10D/R1280DB-family code values with a different function
-  mapping. Not covered by this module.
+The Pre-2017 revision of the R1700BT uses the RC10B remote (5 buttons, no power button).
 """
 
 from enum import IntEnum


### PR DESCRIPTION
## Proposed change

Add a dedicated command set for the 2017 revision of the Edifier
R1700BT (RC10G remote). It reuses the R1280DB-family code values but
with a different function mapping: LINE_1 (0x0A) acts as Bluetooth and
LINE_2 (0x15) acts as Line, while the R1280DB Bluetooth code (0x0E) is
not recognized by this revision.

Mapping confirmed via home-assistant/core#175758.


## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/176721

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
