### PR TITLE
Set explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   prek:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Run prek
@@ -14,6 +18,8 @@ jobs:
 
   pytest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.14"]

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -10,10 +10,14 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   verify:
     name: Verify PR labels
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Verify PR has a valid label
         uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -16,8 +16,6 @@ jobs:
   verify:
     name: Verify PR labels
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     steps:
       - name: Verify PR has a valid label
         uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,13 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

Set explicit workflow permissions as requested in https://github.com/home-assistant-libs/infrared-protocols/pull/95#pullrequestreview-4763545248

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: N/A

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [ ] Lint, format, and type checks pass (`prek --all-files`).
- [ ] Tests pass (`pytest`).
