### PR TITLE
Add Onida AC IR protocol encoder and decoder

### DIFF
--- a/infrared_protocols/commands/onida_ac.py
+++ b/infrared_protocols/commands/onida_ac.py
@@ -1,0 +1,303 @@
+"""Onida air-conditioner IR protocol.
+
+NEC-family timing (9000/4500 leader, 562 mark, 562/1687 spaces), but a custom
+two-frame structure reverse-engineered from a physical Onida remote. Each command
+is two frames sent back to back:
+
+  frame A: leader + 35 data bits + end pulse. Carries the full state.
+  frame B: 32 data bits + end pulse, no leader. Carries the swing detail and the
+           checksum.
+
+Bits are sent least-significant first within each field; index 0 below is the first
+transmitted bit.
+
+Frame A (35 bits):
+  bits 0-2:   mode
+  bit 3:      power
+  bits 4-5:   fan speed
+  bit 6:      swing (set when either vertical or horizontal swing is on)
+  bits 8-11:  temperature (temp_c - 16)
+  bit 20:     turbo
+  bit 21:     display light
+  bit 23:     blow
+  bits 28,30,33: fixed trailer
+
+Frame B (32 bits):
+  bit 0:      vertical swing
+  bit 4:      horizontal swing
+  bit 13:     fixed signature
+  bits 28-31: checksum
+
+Frame A's bit 6 only records that some swing is on; frame B's bits 0 and 4 say which.
+"""
+
+from enum import IntEnum
+from typing import Self, override
+
+from . import Command
+
+MIN_TEMP = 16
+MAX_TEMP = 30
+
+_TEMP_OFFSET = 16
+
+_LEADER_MARK = 9000
+_LEADER_SPACE = 4500
+_BIT_MARK = 562
+_BIT_ONE_SPACE = 1687
+_BIT_ZERO_SPACE = 562
+
+# Between frame A and frame B, and after frame B. The receiver reports this as a
+# clamped idle, so the true gap may be longer; it is a transmit-tuning value.
+_FRAME_GAP = 10000
+
+_FRAME_A_BITS = 35
+_FRAME_B_BITS = 32
+
+_TOLERANCE = 0.35
+# Marks are stretched by receiver AGC far more than spaces, so bit timing is matched
+# with an absolute window that keeps a zero and a one space apart (562 vs 1687).
+_BIT_TOLERANCE = 350
+
+# Frame A field positions (bit index, width), LSB-first within the field.
+_A_MODE = (0, 3)
+_A_POWER = 3
+_A_FAN = (4, 2)
+_A_SWING = 6
+_A_TEMP = (8, 4)
+_A_TURBO = 20
+_A_DISPLAY = 21
+_A_BLOW = 23
+_A_TRAILER = (28, 30, 33)
+
+# Frame B field positions.
+_B_SWING_V = 0
+_B_SWING_H = 4
+_B_SIGNATURE = 13
+_B_CHECKSUM = (28, 4)
+
+# Added into the checksum on top of the state; the contribution of the fixed bits.
+_CHECKSUM_CONST = 12
+
+
+class OnidaAcMode(IntEnum):
+    """AC operating mode; value is the mode field at frame A bits 0-2."""
+
+    AUTO = 0
+    COOL = 1
+    DRY = 2
+    FAN_ONLY = 3
+    HEAT = 4
+
+
+class OnidaAcFanSpeed(IntEnum):
+    """Fan speed; value is the fan field at frame A bits 4-5."""
+
+    AUTO = 0
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+
+
+def _get_field(bits: list[int], start: int, width: int) -> int:
+    """Read a LSB-first field of the given width from a bit list."""
+    return sum(bits[start + i] << i for i in range(width))
+
+
+def _set_field(bits: list[int], start: int, width: int, value: int) -> None:
+    """Write a LSB-first field of the given width into a bit list."""
+    for i in range(width):
+        bits[start + i] = (value >> i) & 1
+
+
+def _checksum(*, mode: int, power: bool, temp: int, swing_h: bool) -> int:
+    """Return the frame B checksum nibble.
+
+    Vertical swing does not enter the checksum; only horizontal does.
+    """
+    total = mode + (8 if power else 0) + (temp - _TEMP_OFFSET)
+    total += (1 if swing_h else 0) + _CHECKSUM_CONST
+    return total & 0xF
+
+
+def _is_close(actual: int, expected: int, tolerance: float) -> bool:
+    """Check if a timing is within the given relative tolerance of the expected."""
+    margin = expected * tolerance
+    return expected - margin <= actual <= expected + margin
+
+
+def _decode_bit(mark: int, space: int) -> int | None:
+    """Decode one bit from its mark and space, or None if it matches neither."""
+    if abs(mark - _BIT_MARK) > _BIT_TOLERANCE:
+        return None
+    if abs(space - _BIT_ZERO_SPACE) <= _BIT_TOLERANCE:
+        return 0
+    if abs(space - _BIT_ONE_SPACE) <= _BIT_TOLERANCE:
+        return 1
+    return None
+
+
+def _encode_frame(bits: list[int], *, leader: bool) -> list[int]:
+    """Encode a bit list into raw timings, with or without the leader."""
+    timings: list[int] = [_LEADER_MARK, -_LEADER_SPACE] if leader else []
+    for bit in bits:
+        timings.append(_BIT_MARK)
+        timings.append(-(_BIT_ONE_SPACE if bit else _BIT_ZERO_SPACE))
+    timings.append(_BIT_MARK)
+    return timings
+
+
+def _decode_bits(timings: list[int], offset: int, count: int) -> list[int] | None:
+    """Decode ``count`` bits starting at ``offset``, or None on any bad bit."""
+    bits: list[int] = []
+    for i in range(count):
+        bit = _decode_bit(timings[offset + 2 * i], abs(timings[offset + 2 * i + 1]))
+        if bit is None:
+            return None
+        bits.append(bit)
+    return bits
+
+
+class OnidaAcCommand(Command):
+    """Onida air-conditioner IR command.
+
+    ``temperature`` is in whole degrees celsius, 16 to 30.
+    """
+
+    power: bool
+    mode: OnidaAcMode
+    temperature: int
+    fan: OnidaAcFanSpeed
+    swing_v: bool
+    swing_h: bool
+    turbo: bool
+    display: bool
+    blow: bool
+
+    def __init__(
+        self,
+        *,
+        power: bool = True,
+        mode: OnidaAcMode,
+        temperature: int,
+        fan: OnidaAcFanSpeed = OnidaAcFanSpeed.AUTO,
+        swing_v: bool = False,
+        swing_h: bool = False,
+        turbo: bool = False,
+        display: bool = True,
+        blow: bool = False,
+        modulation: int = 38000,
+    ) -> None:
+        """Initialize the Onida AC IR command."""
+        super().__init__(modulation=modulation)
+
+        if not MIN_TEMP <= temperature <= MAX_TEMP:
+            raise ValueError(
+                f"temperature {temperature} out of range {MIN_TEMP}..{MAX_TEMP}"
+            )
+
+        self.power = power
+        self.mode = mode
+        self.temperature = temperature
+        self.fan = fan
+        self.swing_v = swing_v
+        self.swing_h = swing_h
+        self.turbo = turbo
+        self.display = display
+        self.blow = blow
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Onida AC command."""
+        frame_a = [0] * _FRAME_A_BITS
+        _set_field(frame_a, *_A_MODE, self.mode.value)
+        frame_a[_A_POWER] = int(self.power)
+        _set_field(frame_a, *_A_FAN, self.fan.value)
+        frame_a[_A_SWING] = int(self.swing_v or self.swing_h)
+        _set_field(frame_a, *_A_TEMP, self.temperature - _TEMP_OFFSET)
+        frame_a[_A_TURBO] = int(self.turbo)
+        frame_a[_A_DISPLAY] = int(self.display)
+        frame_a[_A_BLOW] = int(self.blow)
+        for index in _A_TRAILER:
+            frame_a[index] = 1
+
+        frame_b = [0] * _FRAME_B_BITS
+        frame_b[_B_SWING_V] = int(self.swing_v)
+        frame_b[_B_SWING_H] = int(self.swing_h)
+        frame_b[_B_SIGNATURE] = 1
+        checksum = _checksum(
+            mode=self.mode.value,
+            power=self.power,
+            temp=self.temperature,
+            swing_h=self.swing_h,
+        )
+        _set_field(frame_b, *_B_CHECKSUM, checksum)
+
+        timings = _encode_frame(frame_a, leader=True)
+        timings.append(-_FRAME_GAP)
+        timings.extend(_encode_frame(frame_b, leader=False))
+        timings.append(-_FRAME_GAP)
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into an OnidaAcCommand.
+
+        Expects frame A followed by frame B, as ``get_raw_timings`` emits them.
+        Returns an OnidaAcCommand if the timings match, or None otherwise.
+        """
+        # Frame A: leader (2) + 35 bit pairs (70) + end mark (1).
+        frame_a_len = 2 + 2 * _FRAME_A_BITS + 1
+        # Then the inter-frame gap (1), then frame B: 32 bit pairs (64) + end mark (1).
+        if len(timings) < frame_a_len + 1 + 2 * _FRAME_B_BITS + 1:
+            return None
+
+        if not _is_close(timings[0], _LEADER_MARK, _TOLERANCE) or not _is_close(
+            abs(timings[1]), _LEADER_SPACE, _TOLERANCE
+        ):
+            return None
+
+        frame_a = _decode_bits(timings, 2, _FRAME_A_BITS)
+        if frame_a is None:
+            return None
+        if abs(timings[2 + 2 * _FRAME_A_BITS] - _BIT_MARK) > _BIT_TOLERANCE:
+            return None
+
+        frame_b = _decode_bits(timings, frame_a_len + 1, _FRAME_B_BITS)
+        if frame_b is None:
+            return None
+
+        for index in _A_TRAILER:
+            if frame_a[index] != 1:
+                return None
+        if frame_b[_B_SIGNATURE] != 1:
+            return None
+
+        try:
+            mode = OnidaAcMode(_get_field(frame_a, *_A_MODE))
+            fan = OnidaAcFanSpeed(_get_field(frame_a, *_A_FAN))
+        except ValueError:
+            return None
+
+        temperature = _get_field(frame_a, *_A_TEMP) + _TEMP_OFFSET
+        if not MIN_TEMP <= temperature <= MAX_TEMP:
+            return None
+
+        power = bool(frame_a[_A_POWER])
+        swing_h = bool(frame_b[_B_SWING_H])
+        if _get_field(frame_b, *_B_CHECKSUM) != _checksum(
+            mode=mode.value, power=power, temp=temperature, swing_h=swing_h
+        ):
+            return None
+
+        return cls(
+            power=power,
+            mode=mode,
+            temperature=temperature,
+            fan=fan,
+            swing_v=bool(frame_b[_B_SWING_V]),
+            swing_h=swing_h,
+            turbo=bool(frame_a[_A_TURBO]),
+            display=bool(frame_a[_A_DISPLAY]),
+            blow=bool(frame_a[_A_BLOW]),
+        )

--- a/infrared_protocols/commands/onida_ac.py
+++ b/infrared_protocols/commands/onida_ac.py
@@ -1,17 +1,20 @@
 """Onida air-conditioner IR protocol.
 
-NEC-family timing (9000/4500 leader, 562 mark, 562/1687 spaces), but a custom
-two-frame structure reverse-engineered from a physical Onida remote. Each command
-is two frames sent back to back:
+NEC-family timing (9000/4500 leader, 562 mark, 562/1687 spaces), reverse-engineered
+from a physical Onida remote. A command is a single frame built from two bit blocks
+separated by a long space:
 
-  frame A: leader + 35 data bits + end pulse. Carries the full state.
-  frame B: 32 data bits + end pulse, no leader. Carries the swing detail and the
-           checksum.
+  leader + block A (35 data bits) + end pulse + ~20100 us space
+         + block B (32 data bits) + end pulse
+
+Block A carries the full state; block B carries the swing detail and the checksum.
+(An earlier capture with a too-short receiver idle split this into two frames; it is
+one frame with a long mid-space.)
 
 Bits are sent least-significant first within each field; index 0 below is the first
 transmitted bit.
 
-Frame A (35 bits):
+Block A (35 bits):
   bits 0-2:   mode
   bit 3:      power
   bits 4-5:   fan speed
@@ -22,13 +25,13 @@ Frame A (35 bits):
   bit 23:     blow
   bits 28,30,33: fixed trailer
 
-Frame B (32 bits):
+Block B (32 bits):
   bit 0:      vertical swing
   bit 4:      horizontal swing
   bit 13:     fixed signature
   bits 28-31: checksum
 
-Frame A's bit 6 only records that some swing is on; frame B's bits 0 and 4 say which.
+Block A's bit 6 only records that some swing is on; block B's bits 0 and 4 say which.
 """
 
 from enum import IntEnum
@@ -47,9 +50,8 @@ _BIT_MARK = 562
 _BIT_ONE_SPACE = 1687
 _BIT_ZERO_SPACE = 562
 
-# Between frame A and frame B, and after frame B. The receiver reports this as a
-# clamped idle, so the true gap may be longer; it is a transmit-tuning value.
-_FRAME_GAP = 10000
+# Long mid-frame space after block A, and the trailing space after block B.
+_FRAME_GAP = 20100
 
 _FRAME_A_BITS = 35
 _FRAME_B_BITS = 32
@@ -59,7 +61,7 @@ _TOLERANCE = 0.35
 # with an absolute window that keeps a zero and a one space apart (562 vs 1687).
 _BIT_TOLERANCE = 350
 
-# Frame A field positions (bit index, width), LSB-first within the field.
+# Block A field positions (bit index, width), LSB-first within the field.
 _A_MODE = (0, 3)
 _A_POWER = 3
 _A_FAN = (4, 2)
@@ -70,7 +72,7 @@ _A_DISPLAY = 21
 _A_BLOW = 23
 _A_TRAILER = (28, 30, 33)
 
-# Frame B field positions.
+# Block B field positions.
 _B_SWING_V = 0
 _B_SWING_H = 4
 _B_SIGNATURE = 13
@@ -81,7 +83,7 @@ _CHECKSUM_CONST = 12
 
 
 class OnidaAcMode(IntEnum):
-    """AC operating mode; value is the mode field at frame A bits 0-2."""
+    """AC operating mode; value is the mode field at block A bits 0-2."""
 
     AUTO = 0
     COOL = 1
@@ -91,7 +93,7 @@ class OnidaAcMode(IntEnum):
 
 
 class OnidaAcFanSpeed(IntEnum):
-    """Fan speed; value is the fan field at frame A bits 4-5."""
+    """Fan speed; value is the fan field at block A bits 4-5."""
 
     AUTO = 0
     LOW = 1
@@ -111,7 +113,7 @@ def _set_field(bits: list[int], start: int, width: int, value: int) -> None:
 
 
 def _checksum(*, mode: int, power: bool, temp: int, swing_h: bool) -> int:
-    """Return the frame B checksum nibble.
+    """Return the block B checksum nibble.
 
     Vertical swing does not enter the checksum; only horizontal does.
     """
@@ -243,12 +245,12 @@ class OnidaAcCommand(Command):
     def from_raw_timings(cls, timings: list[int]) -> Self | None:
         """Decode raw IR timings into an OnidaAcCommand.
 
-        Expects frame A followed by frame B, as ``get_raw_timings`` emits them.
+        Expects block A followed by block B, as ``get_raw_timings`` emits them.
         Returns an OnidaAcCommand if the timings match, or None otherwise.
         """
-        # Frame A: leader (2) + 35 bit pairs (70) + end mark (1).
+        # Block A: leader (2) + 35 bit pairs (70) + end mark (1).
         frame_a_len = 2 + 2 * _FRAME_A_BITS + 1
-        # Then the inter-frame gap (1), then frame B: 32 bit pairs (64) + end mark (1).
+        # Then the mid-frame gap (1), then block B: 32 bit pairs (64) + end mark (1).
         if len(timings) < frame_a_len + 1 + 2 * _FRAME_B_BITS + 1:
             return None
 

--- a/infrared_protocols/commands/onida_ac.py
+++ b/infrared_protocols/commands/onida_ac.py
@@ -18,7 +18,7 @@ Block A (35 bits):
   bits 0-2:   mode
   bit 3:      power
   bits 4-5:   fan speed
-  bit 6:      swing (set when either vertical or horizontal swing is on)
+  bit 6:      swing (set while either axis is actually swinging)
   bits 8-11:  temperature (temp_c - 16)
   bit 20:     turbo
   bit 21:     display light
@@ -31,7 +31,10 @@ Block B (32 bits):
   bit 13:     fixed signature
   bits 28-31: checksum
 
-Block A's bit 6 only records that some swing is on; block B's bits 0 and 4 say which.
+Block A's bit 6 records whether anything is swinging; block B's bits 0 and 4 say which
+axis. Block B's bits latch: they keep the last selected axis after swing is switched
+off, so they only describe live movement while block A's bit 6 is set. The checksum is
+computed over block B's latched horizontal bit rather than the effective state.
 """
 
 from enum import IntEnum
@@ -265,8 +268,17 @@ class OnidaAcCommand(Command):
         if abs(timings[2 + 2 * _FRAME_A_BITS] - _BIT_MARK) > _BIT_TOLERANCE:
             return None
 
-        frame_b = _decode_bits(timings, frame_a_len + 1, _FRAME_B_BITS)
+        # The mid-frame gap is a space, so it must be negative as well as long.
+        if timings[frame_a_len] >= 0 or not _is_close(
+            abs(timings[frame_a_len]), _FRAME_GAP, _TOLERANCE
+        ):
+            return None
+
+        frame_b_start = frame_a_len + 1
+        frame_b = _decode_bits(timings, frame_b_start, _FRAME_B_BITS)
         if frame_b is None:
+            return None
+        if abs(timings[frame_b_start + 2 * _FRAME_B_BITS] - _BIT_MARK) > _BIT_TOLERANCE:
             return None
 
         for index in _A_TRAILER:
@@ -286,9 +298,18 @@ class OnidaAcCommand(Command):
             return None
 
         power = bool(frame_a[_A_POWER])
-        swing_h = bool(frame_b[_B_SWING_H])
+        # Block B's two bits latch the axis last selected and keep that value after
+        # swing is switched off, so block A's bit is what says whether anything is
+        # actually swinging. Turning one axis off while both ran sends block A's bit
+        # clear with the other axis still set in block B.
+        latched_swing_h = bool(frame_b[_B_SWING_H])
+        swinging = bool(frame_a[_A_SWING])
+        swing_v = swinging and bool(frame_b[_B_SWING_V])
+        swing_h = swinging and latched_swing_h
+
+        # The checksum is computed over block B's latched bit, not the effective state.
         if _get_field(frame_b, *_B_CHECKSUM) != _checksum(
-            mode=mode.value, power=power, temp=temperature, swing_h=swing_h
+            mode=mode.value, power=power, temp=temperature, swing_h=latched_swing_h
         ):
             return None
 
@@ -297,7 +318,7 @@ class OnidaAcCommand(Command):
             mode=mode,
             temperature=temperature,
             fan=fan,
-            swing_v=bool(frame_b[_B_SWING_V]),
+            swing_v=swing_v,
             swing_h=swing_h,
             turbo=bool(frame_a[_A_TURBO]),
             display=bool(frame_a[_A_DISPLAY]),

--- a/tests/commands/test_onida_ac.py
+++ b/tests/commands/test_onida_ac.py
@@ -1,0 +1,370 @@
+"""Tests for the Onida air-conditioner IR command."""
+
+import pytest
+
+from infrared_protocols.commands.onida_ac import (
+    OnidaAcCommand,
+    OnidaAcFanSpeed,
+    OnidaAcMode,
+)
+
+# Physical-layer constants are duplicated here rather than imported
+# so the tests are independent
+_FRAME_A_BITS = 35
+_FRAME_B_BITS = 32
+_BIT_ONE_SPACE = 1687
+_BIT_ZERO_SPACE = 562
+
+_ONE_THRESHOLD = (_BIT_ONE_SPACE + _BIT_ZERO_SPACE) // 2
+
+# Each entry is the (frame A, frame B) bitstrings, MSB index 0 = first
+# transmitted bit, exactly as the remote sends them.
+_CAPTURED = {
+    "cool_24_baseline": (
+        "10010000000100000000010000001010010",
+        "00000000000001000000000000001011",
+    ),
+    "cool_16_swing_both": (
+        "10010010000000000000010000001010010",
+        "10001000000001000000000000000110",
+    ),
+    "cool_30_swing_both": (
+        "10010010011100000000010000001010010",
+        "10001000000001000000000000000010",
+    ),
+    "dry_24": (
+        "01011000000100000000010000001010010",
+        "00000000000001000000000000000111",
+    ),
+    "heat_25": (
+        "00110000100100000000010000001010010",
+        "00000000000001000000000000001000",
+    ),
+    "auto_25": (
+        "00010000100100000000010000001010010",
+        "00000000000001000000000000001011",
+    ),
+    "power_off_swing_both": (
+        "10000010000100000000010000001010010",
+        "10001000000001000000000000000110",
+    ),
+    "cool_25_hswing": (
+        "10010010100100000000010000001010010",
+        "00001000000001000000000000001111",
+    ),
+    "cool_25_vswing": (
+        "10010010100100000000010000001010010",
+        "10000000000001000000000000000111",
+    ),
+}
+
+
+def _bits_to_int_lsb(bits: str, start: int, width: int) -> int:
+    return sum((1 if bits[start + i] == "1" else 0) << i for i in range(width))
+
+
+def _extract_frames(timings: list[int]) -> tuple[str, str]:
+    """Pull the frame A and frame B bitstrings back out of raw timings."""
+    frame_a = "".join(
+        "1" if abs(timings[3 + 2 * i]) > _ONE_THRESHOLD else "0"
+        for i in range(_FRAME_A_BITS)
+    )
+    frame_b_start = 2 + 2 * _FRAME_A_BITS + 1 + 1
+    frame_b = "".join(
+        "1" if abs(timings[frame_b_start + 1 + 2 * i]) > _ONE_THRESHOLD else "0"
+        for i in range(_FRAME_B_BITS)
+    )
+    return frame_a, frame_b
+
+
+def _frame_a_space(index: int) -> int:
+    """Return the timing index of the space for frame A data bit ``index``."""
+    return 3 + 2 * index
+
+
+def _frame_b_space(index: int) -> int:
+    """Return the timing index of the space for frame B data bit ``index``."""
+    frame_b_start = 2 + 2 * _FRAME_A_BITS + 1 + 1
+    return frame_b_start + 1 + 2 * index
+
+
+def _command_for(label: str) -> OnidaAcCommand:
+    """Build the command whose state matches a captured frame."""
+    a, b = _CAPTURED[label]
+    return OnidaAcCommand(
+        power=a[3] == "1",
+        mode=OnidaAcMode(_bits_to_int_lsb(a, 0, 3)),
+        temperature=_bits_to_int_lsb(a, 8, 4) + 16,
+        fan=OnidaAcFanSpeed(_bits_to_int_lsb(a, 4, 2)),
+        swing_v=b[0] == "1",
+        swing_h=b[4] == "1",
+        turbo=a[20] == "1",
+        display=a[21] == "1",
+        blow=a[23] == "1",
+    )
+
+
+def test_encode_timing_values() -> None:
+    """Pin the physical layer: leader, bit mark, and the two bit spaces."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+
+    assert timings[:2] == [9000, -4500]
+    assert timings[2::2].count(562) > 0
+    marks = [t for t in timings if t > 0]
+    assert set(marks) == {9000, 562}
+    spaces = {abs(t) for t in timings if t < 0}
+    assert spaces == {4500, 1687, 562, 10000}
+
+
+@pytest.mark.parametrize("label", list(_CAPTURED))
+def test_encode_matches_captured_frames(label: str) -> None:
+    """The encoder reproduces frames captured from a physical remote, bit for bit."""
+    frame_a, frame_b = _extract_frames(_command_for(label).get_raw_timings())
+
+    assert (frame_a, frame_b) == _CAPTURED[label]
+
+
+@pytest.mark.parametrize("label", list(_CAPTURED))
+def test_decode_captured_frames(label: str) -> None:
+    """A captured frame decodes back to the state it was sent with."""
+    expected = _command_for(label)
+    result = OnidaAcCommand.from_raw_timings(expected.get_raw_timings())
+
+    assert result is not None
+    assert result.power is expected.power
+    assert result.mode is expected.mode
+    assert result.temperature == expected.temperature
+    assert result.fan is expected.fan
+    assert result.swing_v is expected.swing_v
+    assert result.swing_h is expected.swing_h
+    assert result.turbo is expected.turbo
+    assert result.display is expected.display
+    assert result.blow is expected.blow
+
+
+def test_swing_v_and_h_share_frame_a_bit() -> None:
+    """Frame A carries a single swing bit; frame B distinguishes v from h."""
+    v_only = _extract_frames(
+        OnidaAcCommand(
+            mode=OnidaAcMode.COOL, temperature=24, swing_v=True
+        ).get_raw_timings()
+    )
+    h_only = _extract_frames(
+        OnidaAcCommand(
+            mode=OnidaAcMode.COOL, temperature=24, swing_h=True
+        ).get_raw_timings()
+    )
+
+    assert v_only[0] == h_only[0]  # frame A identical
+    assert v_only[1] != h_only[1]  # frame B differs
+
+
+def test_horizontal_swing_changes_checksum_vertical_does_not() -> None:
+    """Only horizontal swing enters the checksum."""
+    base = _extract_frames(
+        OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    )[1]
+    v = _extract_frames(
+        OnidaAcCommand(
+            mode=OnidaAcMode.COOL, temperature=24, swing_v=True
+        ).get_raw_timings()
+    )[1]
+    h = _extract_frames(
+        OnidaAcCommand(
+            mode=OnidaAcMode.COOL, temperature=24, swing_h=True
+        ).get_raw_timings()
+    )[1]
+
+    assert base[28:] == v[28:]
+    assert base[28:] != h[28:]
+
+
+@pytest.mark.parametrize(
+    ("power", "mode", "temperature", "fan", "swing_v", "swing_h", "turbo", "blow"),
+    [
+        pytest.param(
+            True,
+            OnidaAcMode.COOL,
+            16,
+            OnidaAcFanSpeed.AUTO,
+            False,
+            False,
+            False,
+            False,
+            id="cool_min",
+        ),
+        pytest.param(
+            True,
+            OnidaAcMode.DRY,
+            30,
+            OnidaAcFanSpeed.HIGH,
+            True,
+            True,
+            True,
+            True,
+            id="dry_max_all_on",
+        ),
+        pytest.param(
+            False,
+            OnidaAcMode.FAN_ONLY,
+            23,
+            OnidaAcFanSpeed.MEDIUM,
+            True,
+            False,
+            False,
+            True,
+            id="off_fanonly",
+        ),
+        pytest.param(
+            True,
+            OnidaAcMode.COOL,
+            21,
+            OnidaAcFanSpeed.LOW,
+            False,
+            True,
+            True,
+            False,
+            id="cool_hswing_turbo",
+        ),
+    ],
+)
+def test_roundtrip(
+    power: bool,
+    mode: OnidaAcMode,
+    temperature: int,
+    fan: OnidaAcFanSpeed,
+    swing_v: bool,
+    swing_h: bool,
+    turbo: bool,
+    blow: bool,
+) -> None:
+    """Every encodable state decodes back to the settings it was built from."""
+    cmd = OnidaAcCommand(
+        power=power,
+        mode=mode,
+        temperature=temperature,
+        fan=fan,
+        swing_v=swing_v,
+        swing_h=swing_h,
+        turbo=turbo,
+        blow=blow,
+    )
+    result = OnidaAcCommand.from_raw_timings(cmd.get_raw_timings())
+
+    assert result is not None
+    assert result.power is power
+    assert result.mode is mode
+    assert result.temperature == temperature
+    assert result.fan is fan
+    assert result.swing_v is swing_v
+    assert result.swing_h is swing_h
+    assert result.turbo is turbo
+    assert result.blow is blow
+
+
+def test_default_modulation() -> None:
+    """The command defaults to 38 kHz and sends a single command."""
+    cmd = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24)
+
+    assert cmd.modulation == 38000
+    assert cmd.repeat_count == 0
+
+
+@pytest.mark.parametrize(
+    "temperature",
+    [
+        pytest.param(15, id="below_min"),
+        pytest.param(31, id="above_max"),
+        pytest.param(0, id="zero"),
+    ],
+)
+def test_temperature_out_of_range(temperature: int) -> None:
+    """A temperature outside 16..30 is rejected."""
+    with pytest.raises(ValueError, match="out of range"):
+        OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=temperature)
+
+
+def test_decode_returns_none_for_short_timings() -> None:
+    """A truncated frame is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+
+    assert OnidaAcCommand.from_raw_timings(timings[:100]) is None
+
+
+@pytest.mark.parametrize(
+    ("index", "value"),
+    [
+        pytest.param(0, 3000, id="leader_mark"),
+        pytest.param(1, -1650, id="leader_space"),
+    ],
+)
+def test_decode_returns_none_for_invalid_leader(index: int, value: int) -> None:
+    """A frame with a leader outside tolerance is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    timings[index] = value
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+def test_decode_returns_none_for_bad_checksum() -> None:
+    """A frame whose checksum does not match its state is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    # Bit 28 of frame B is a one here; forcing it to a zero corrupts the checksum.
+    timings[_frame_b_space(28)] = -_BIT_ZERO_SPACE
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+def test_decode_returns_none_for_nec_signal() -> None:
+    """A standard NEC signal (no second frame) is rejected."""
+    timings = [9000, -4500]
+    for _ in range(32):
+        timings += [562, -1687]
+    timings.append(562)
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+@pytest.mark.parametrize(
+    ("space_index", "space_value"),
+    [
+        pytest.param(_frame_a_space(28), -_BIT_ZERO_SPACE, id="trailer_bit_28_cleared"),
+        pytest.param(_frame_a_space(30), -_BIT_ZERO_SPACE, id="trailer_bit_30_cleared"),
+        pytest.param(_frame_a_space(33), -_BIT_ZERO_SPACE, id="trailer_bit_33_cleared"),
+        pytest.param(_frame_b_space(13), -_BIT_ZERO_SPACE, id="signature_cleared"),
+        pytest.param(_frame_a_space(2), -_BIT_ONE_SPACE, id="mode_field_undefined"),
+    ],
+)
+def test_decode_returns_none_for_corrupted_bit(
+    space_index: int, space_value: int
+) -> None:
+    """A cleared marker bit or an out-of-range mode field is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    timings[space_index] = space_value
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+def test_decode_returns_none_for_decoded_temperature_out_of_range() -> None:
+    """A temperature field that decodes above the max is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=30).get_raw_timings()
+    # 30 °C encodes temp field 14 (bits 8-11); setting bit 8 makes it 15 -> 31 °C.
+    timings[_frame_a_space(8)] = -_BIT_ONE_SPACE
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+def test_decode_returns_none_for_bad_data_bit() -> None:
+    """A data bit whose mark is out of tolerance is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    timings[2] = 3000  # first frame A bit mark, far from the 562 nominal
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+def test_decode_returns_none_for_bad_frame_a_end_mark() -> None:
+    """A frame A whose terminating mark is out of tolerance is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    timings[2 + 2 * _FRAME_A_BITS] = 3000
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None

--- a/tests/commands/test_onida_ac.py
+++ b/tests/commands/test_onida_ac.py
@@ -17,7 +17,7 @@ _BIT_ZERO_SPACE = 562
 
 _ONE_THRESHOLD = (_BIT_ONE_SPACE + _BIT_ZERO_SPACE) // 2
 
-# Each entry is the (frame A, frame B) bitstrings, MSB index 0 = first
+# Each entry is the (block A, block B) bitstrings, MSB index 0 = first
 # transmitted bit, exactly as the remote sends them.
 _CAPTURED = {
     "cool_24_baseline": (
@@ -64,7 +64,7 @@ def _bits_to_int_lsb(bits: str, start: int, width: int) -> int:
 
 
 def _extract_frames(timings: list[int]) -> tuple[str, str]:
-    """Pull the frame A and frame B bitstrings back out of raw timings."""
+    """Pull the block A and block B bitstrings back out of raw timings."""
     frame_a = "".join(
         "1" if abs(timings[3 + 2 * i]) > _ONE_THRESHOLD else "0"
         for i in range(_FRAME_A_BITS)
@@ -78,12 +78,12 @@ def _extract_frames(timings: list[int]) -> tuple[str, str]:
 
 
 def _frame_a_space(index: int) -> int:
-    """Return the timing index of the space for frame A data bit ``index``."""
+    """Return the timing index of the space for block A data bit ``index``."""
     return 3 + 2 * index
 
 
 def _frame_b_space(index: int) -> int:
-    """Return the timing index of the space for frame B data bit ``index``."""
+    """Return the timing index of the space for block B data bit ``index``."""
     frame_b_start = 2 + 2 * _FRAME_A_BITS + 1 + 1
     return frame_b_start + 1 + 2 * index
 
@@ -113,7 +113,7 @@ def test_encode_timing_values() -> None:
     marks = [t for t in timings if t > 0]
     assert set(marks) == {9000, 562}
     spaces = {abs(t) for t in timings if t < 0}
-    assert spaces == {4500, 1687, 562, 10000}
+    assert spaces == {4500, 1687, 562, 20100}
 
 
 @pytest.mark.parametrize("label", list(_CAPTURED))
@@ -143,7 +143,7 @@ def test_decode_captured_frames(label: str) -> None:
 
 
 def test_swing_v_and_h_share_frame_a_bit() -> None:
-    """Frame A carries a single swing bit; frame B distinguishes v from h."""
+    """Block A carries a single swing bit; block B distinguishes v from h."""
     v_only = _extract_frames(
         OnidaAcCommand(
             mode=OnidaAcMode.COOL, temperature=24, swing_v=True
@@ -155,8 +155,8 @@ def test_swing_v_and_h_share_frame_a_bit() -> None:
         ).get_raw_timings()
     )
 
-    assert v_only[0] == h_only[0]  # frame A identical
-    assert v_only[1] != h_only[1]  # frame B differs
+    assert v_only[0] == h_only[0]  # block A identical
+    assert v_only[1] != h_only[1]  # block B differs
 
 
 def test_horizontal_swing_changes_checksum_vertical_does_not() -> None:
@@ -309,7 +309,7 @@ def test_decode_returns_none_for_invalid_leader(index: int, value: int) -> None:
 def test_decode_returns_none_for_bad_checksum() -> None:
     """A frame whose checksum does not match its state is rejected."""
     timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
-    # Bit 28 of frame B is a one here; forcing it to a zero corrupts the checksum.
+    # Bit 28 of block B is a one here; forcing it to a zero corrupts the checksum.
     timings[_frame_b_space(28)] = -_BIT_ZERO_SPACE
 
     assert OnidaAcCommand.from_raw_timings(timings) is None
@@ -357,13 +357,13 @@ def test_decode_returns_none_for_decoded_temperature_out_of_range() -> None:
 def test_decode_returns_none_for_bad_data_bit() -> None:
     """A data bit whose mark is out of tolerance is rejected."""
     timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
-    timings[2] = 3000  # first frame A bit mark, far from the 562 nominal
+    timings[2] = 3000  # first block A bit mark, far from the 562 nominal
 
     assert OnidaAcCommand.from_raw_timings(timings) is None
 
 
 def test_decode_returns_none_for_bad_frame_a_end_mark() -> None:
-    """A frame A whose terminating mark is out of tolerance is rejected."""
+    """A block A whose terminating mark is out of tolerance is rejected."""
     timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
     timings[2 + 2 * _FRAME_A_BITS] = 3000
 

--- a/tests/commands/test_onida_ac.py
+++ b/tests/commands/test_onida_ac.py
@@ -12,13 +12,22 @@ from infrared_protocols.commands.onida_ac import (
 # so the tests are independent
 _FRAME_A_BITS = 35
 _FRAME_B_BITS = 32
+_LEADER_MARK = 9000
+_LEADER_SPACE = 4500
+_BIT_MARK = 562
 _BIT_ONE_SPACE = 1687
 _BIT_ZERO_SPACE = 562
+_FRAME_GAP = 20100
 
 _ONE_THRESHOLD = (_BIT_ONE_SPACE + _BIT_ZERO_SPACE) // 2
 
-# Each entry is the (block A, block B) bitstrings, MSB index 0 = first
-# transmitted bit, exactly as the remote sends them.
+# Leader (2) + block A bit pairs + block A end mark.
+_MID_GAP_INDEX = 2 + 2 * _FRAME_A_BITS + 1
+_FRAME_B_START = _MID_GAP_INDEX + 1
+_FRAME_B_END_MARK_INDEX = _FRAME_B_START + 2 * _FRAME_B_BITS
+
+# Each entry is the (block A, block B) bitstrings in transmission order:
+# index 0 is the first bit on the wire, exactly as the remote sends them.
 _CAPTURED = {
     "cool_24_baseline": (
         "10010000000100000000010000001010010",
@@ -56,6 +65,18 @@ _CAPTURED = {
         "10010010100100000000010000001010010",
         "10000000000001000000000000000111",
     ),
+    "cool_24_fan_low": (
+        "10011000000100000000010000001010010",
+        "00000000000001000000000000001011",
+    ),
+    "cool_24_fan_medium_swing_both": (
+        "10010110000100000000010000001010010",
+        "10001000000001000000000000000111",
+    ),
+    "cool_24_fan_high_swing_both": (
+        "10011110000100000000010000001010010",
+        "10001000000001000000000000000111",
+    ),
 }
 
 
@@ -69,12 +90,23 @@ def _extract_frames(timings: list[int]) -> tuple[str, str]:
         "1" if abs(timings[3 + 2 * i]) > _ONE_THRESHOLD else "0"
         for i in range(_FRAME_A_BITS)
     )
-    frame_b_start = 2 + 2 * _FRAME_A_BITS + 1 + 1
     frame_b = "".join(
-        "1" if abs(timings[frame_b_start + 1 + 2 * i]) > _ONE_THRESHOLD else "0"
+        "1" if abs(timings[_FRAME_B_START + 1 + 2 * i]) > _ONE_THRESHOLD else "0"
         for i in range(_FRAME_B_BITS)
     )
     return frame_a, frame_b
+
+
+def _build_timings(frame_a: str, frame_b: str) -> list[int]:
+    """Build raw timings from two bitstrings without going through the encoder."""
+    timings = [_LEADER_MARK, -_LEADER_SPACE]
+    for bit in frame_a:
+        timings += [_BIT_MARK, -(_BIT_ONE_SPACE if bit == "1" else _BIT_ZERO_SPACE)]
+    timings += [_BIT_MARK, -_FRAME_GAP]
+    for bit in frame_b:
+        timings += [_BIT_MARK, -(_BIT_ONE_SPACE if bit == "1" else _BIT_ZERO_SPACE)]
+    timings += [_BIT_MARK, -_FRAME_GAP]
+    return timings
 
 
 def _frame_a_space(index: int) -> int:
@@ -84,8 +116,7 @@ def _frame_a_space(index: int) -> int:
 
 def _frame_b_space(index: int) -> int:
     """Return the timing index of the space for block B data bit ``index``."""
-    frame_b_start = 2 + 2 * _FRAME_A_BITS + 1 + 1
-    return frame_b_start + 1 + 2 * index
+    return _FRAME_B_START + 1 + 2 * index
 
 
 def _command_for(label: str) -> OnidaAcCommand:
@@ -362,9 +393,58 @@ def test_decode_returns_none_for_bad_data_bit() -> None:
     assert OnidaAcCommand.from_raw_timings(timings) is None
 
 
-def test_decode_returns_none_for_bad_frame_a_end_mark() -> None:
-    """A block A whose terminating mark is out of tolerance is rejected."""
+@pytest.mark.parametrize(
+    "index",
+    [
+        pytest.param(2 + 2 * _FRAME_A_BITS, id="block_a"),
+        pytest.param(_FRAME_B_END_MARK_INDEX, id="block_b"),
+    ],
+)
+def test_decode_returns_none_for_bad_end_mark(index: int) -> None:
+    """A block whose terminating mark is out of tolerance is rejected."""
     timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
-    timings[2 + 2 * _FRAME_A_BITS] = 3000
+    timings[index] = 3000
 
     assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+@pytest.mark.parametrize(
+    "gap",
+    [
+        pytest.param(-_BIT_ONE_SPACE, id="too_short"),
+        pytest.param(-60000, id="too_long"),
+        pytest.param(20100, id="mark_not_space"),
+    ],
+)
+def test_decode_returns_none_for_bad_mid_frame_gap(gap: int) -> None:
+    """A frame whose mid-frame gap is not the expected long space is rejected."""
+    timings = OnidaAcCommand(mode=OnidaAcMode.COOL, temperature=24).get_raw_timings()
+    timings[_MID_GAP_INDEX] = gap
+
+    assert OnidaAcCommand.from_raw_timings(timings) is None
+
+
+# Captured by switching one axis off while both were swinging. Block A's swing bit is
+# clear while block B still carries the other axis, so these cannot be produced by the
+# encoder and are decode-only.
+_CAPTURED_LATCHED_SWING = {
+    "v_off_from_both": (
+        "10010000000100000000010000001010010",
+        "00001000000001000000000000000111",
+    ),
+    "h_off_from_both": (
+        "10010000000100000000010000001010010",
+        "10000000000001000000000000001011",
+    ),
+}
+
+
+@pytest.mark.parametrize("label", list(_CAPTURED_LATCHED_SWING))
+def test_decode_latched_swing_bits_read_as_off(label: str) -> None:
+    """Block B's swing bits only count while block A says something is swinging."""
+    frame_a, frame_b = _CAPTURED_LATCHED_SWING[label]
+    result = OnidaAcCommand.from_raw_timings(_build_timings(frame_a, frame_b))
+
+    assert result is not None
+    assert result.swing_v is False
+    assert result.swing_h is False


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->
Onida AC support

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/177189

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
