### PR TITLE
Add proper command set for Edifier R2000DB

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -15,6 +15,7 @@ class EdifierCommandSet(StrEnum):
     R1700BTS = "r1700bts"
     R1280DB = "r1280db"
     R1280T = "r1280t"
+    R2000DB = "r2000db"
     S360DB = "s360db"
     RC20G = "rc20g"
     S3000PRO = "s3000pro"
@@ -36,9 +37,10 @@ class EdifierModel(StrEnum):
     R1280DB = "R1280DB"
     R2730DB = "R2730DB"
     RC10D1 = "RC10D1"
-    R2000DB = "R2000DB"
     # R1280T command set (basic)
     R1280T = "R1280T"
+    # R2000DB command set (RC10D remote)
+    R2000DB = "R2000DB"
     # S360DB command set
     S360DB = "S360DB"
     RC31A = "RC31A"
@@ -62,9 +64,10 @@ MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
     EdifierModel.R1280DB: EdifierCommandSet.R1280DB,
     EdifierModel.R2730DB: EdifierCommandSet.R1280DB,
     EdifierModel.RC10D1: EdifierCommandSet.R1280DB,
-    EdifierModel.R2000DB: EdifierCommandSet.R1280DB,
     # R1280T command set
     EdifierModel.R1280T: EdifierCommandSet.R1280T,
+    # R2000DB command set
+    EdifierModel.R2000DB: EdifierCommandSet.R2000DB,
     # S360DB command set
     EdifierModel.S360DB: EdifierCommandSet.S360DB,
     EdifierModel.RC31A: EdifierCommandSet.S360DB,

--- a/infrared_protocols/codes/edifier/r1280db.py
+++ b/infrared_protocols/codes/edifier/r1280db.py
@@ -1,6 +1,6 @@
 """Command codes for Edifier R1280DB speakers.
 
-Shared command set used by R1280DB, R2730DB, RC10D1, and R2000DB.
+Shared command set used by R1280DB, R2730DB, and RC10D1.
 """
 
 from enum import IntEnum

--- a/infrared_protocols/codes/edifier/r2000db.py
+++ b/infrared_protocols/codes/edifier/r2000db.py
@@ -1,0 +1,25 @@
+"""Command codes for Edifier R2000DB speakers."""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class EdifierR2000DBCode(IntEnum):
+    """Edifier R2000DB speaker IR command codes."""
+
+    POWER = 0x00
+    VOLUME_UP = 0x09
+    VOLUME_DOWN = 0x0C
+    MUTE = 0x01
+    LINE_1 = 0x0D
+    LINE_2 = 0x16
+    OPTICAL = 0x0A
+    BLUETOOTH = 0x15
+    EQ_CLASSIC = 0x0E
+    EQ_DYNAMIC = 0x14
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NECCommand."""
+        return NECCommand(address=0xE710, command=self.value, repeat_count=repeat_count)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->
As reported in home-assistant/core/issues/177226 the R2000DB is using the wrong code set.
This fixes it (also validated against the Flipper IRDB repo codes).

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/177472

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
