### PR TITLE
Add proper command set for Edifier R2730DB

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -16,6 +16,7 @@ class EdifierCommandSet(StrEnum):
     R1280DB = "r1280db"
     R1280T = "r1280t"
     R2000DB = "r2000db"
+    R2730DB = "r2730db"
     S360DB = "s360db"
     RC20G = "rc20g"
     S3000PRO = "s3000pro"
@@ -35,12 +36,13 @@ class EdifierModel(StrEnum):
     R1855DB = "R1855DB"
     # R1280DB command set
     R1280DB = "R1280DB"
-    R2730DB = "R2730DB"
-    RC10D1 = "RC10D1"
     # R1280T command set (basic)
     R1280T = "R1280T"
     # R2000DB command set (RC10D remote)
     R2000DB = "R2000DB"
+    # R2730DB command set (RC10D1 remote)
+    R2730DB = "R2730DB"
+    RC10D1 = "RC10D1"
     # S360DB command set
     S360DB = "S360DB"
     RC31A = "RC31A"
@@ -62,12 +64,13 @@ MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
     EdifierModel.R1855DB: EdifierCommandSet.R1700BTS,
     # R1280DB command set
     EdifierModel.R1280DB: EdifierCommandSet.R1280DB,
-    EdifierModel.R2730DB: EdifierCommandSet.R1280DB,
-    EdifierModel.RC10D1: EdifierCommandSet.R1280DB,
     # R1280T command set
     EdifierModel.R1280T: EdifierCommandSet.R1280T,
     # R2000DB command set
     EdifierModel.R2000DB: EdifierCommandSet.R2000DB,
+    # R2730DB command set
+    EdifierModel.R2730DB: EdifierCommandSet.R2730DB,
+    EdifierModel.RC10D1: EdifierCommandSet.R2730DB,
     # S360DB command set
     EdifierModel.S360DB: EdifierCommandSet.S360DB,
     EdifierModel.RC31A: EdifierCommandSet.S360DB,

--- a/infrared_protocols/codes/edifier/r2730db.py
+++ b/infrared_protocols/codes/edifier/r2730db.py
@@ -1,4 +1,7 @@
-"""Command codes for Edifier R1280DB speakers."""
+"""Command codes for Edifier R2730DB speakers.
+
+Shared command set used by R2730DB and RC10D1.
+"""
 
 from enum import IntEnum
 
@@ -6,16 +9,13 @@ from ...commands import Command
 from ...commands.nec import NECCommand
 
 
-class EdifierR1280DBCode(IntEnum):
-    """Edifier R1280DB speaker IR command codes."""
+class EdifierR2730DBCode(IntEnum):
+    """Edifier R2730DB speaker IR command codes."""
 
-    POWER = 0x01
+    POWER = 0x00
     VOLUME_UP = 0x09
     VOLUME_DOWN = 0x0C
-    MUTE = 0x00
-    PLAY_PAUSE = 0x14
-    FORWARD = 0x08
-    BACK = 0x06
+    MUTE = 0x01
     LINE_1 = 0x0A
     LINE_2 = 0x15
     OPTICAL = 0x0D


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->
While working on https://github.com/home-assistant-libs/infrared-protocols/pull/109 I found out that the R2730DB had the power and mute codes swapped (according to Flipper IRDB), so it needs a new code set.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/177472

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
