### PR TITLE
Add generic 10-key LED candle remote codes

### DIFF
--- a/infrared_protocols/codes/generic/led/__init__.py
+++ b/infrared_protocols/codes/generic/led/__init__.py
@@ -1,6 +1,7 @@
 """Generic LED remote control IR command codes."""
 
 from .base import BaseGenericLEDCode
+from .generic_10_key import Generic10KeyCode
 from .generic_13_key import Generic13KeyCode
 from .generic_24_key import Generic24KeyCode
 from .generic_40_key import Generic40KeyCode
@@ -8,6 +9,7 @@ from .generic_44_key import Generic44KeyCode
 
 __all__ = [
     "BaseGenericLEDCode",
+    "Generic10KeyCode",
     "Generic13KeyCode",
     "Generic24KeyCode",
     "Generic40KeyCode",

--- a/infrared_protocols/codes/generic/led/__init__.py
+++ b/infrared_protocols/codes/generic/led/__init__.py
@@ -1,11 +1,13 @@
 """Generic LED remote control IR command codes."""
 
+from .base import BaseGenericLEDCode
 from .generic_13_key import Generic13KeyCode
 from .generic_24_key import Generic24KeyCode
 from .generic_40_key import Generic40KeyCode
 from .generic_44_key import Generic44KeyCode
 
 __all__ = [
+    "BaseGenericLEDCode",
     "Generic13KeyCode",
     "Generic24KeyCode",
     "Generic40KeyCode",

--- a/infrared_protocols/codes/generic/led/base.py
+++ b/infrared_protocols/codes/generic/led/base.py
@@ -1,0 +1,14 @@
+"""Base class for generic LED remote control IR command codes."""
+
+from abc import abstractmethod
+from enum import IntEnum
+
+from ....commands import Command
+
+
+class BaseGenericLEDCode(IntEnum):
+    """Base class for generic LED remote control IR command codes."""
+
+    @abstractmethod
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build a command."""

--- a/infrared_protocols/codes/generic/led/generic_10_key.py
+++ b/infrared_protocols/codes/generic/led/generic_10_key.py
@@ -1,0 +1,30 @@
+"""Command codes for generic 10-key LED candle remote control."""
+
+from ....commands import Command
+from ....commands.nec import NECCommand
+from .base import BaseGenericLEDCode
+
+
+class Generic10KeyCode(BaseGenericLEDCode):
+    """Generic 10-key LED candle remote control IR command codes."""
+
+    ON = 0x01
+    OFF = 0x00
+    BRIGHTNESS_UP = 0x14
+    BRIGHTNESS_DOWN = 0x0E
+
+    TIMER_2H = 0x0C
+    TIMER_4H = 0x09
+    TIMER_6H = 0x0A
+    TIMER_8H = 0x15
+
+    CANDLE = 0x0D
+    LIGHT = 0x16
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build a NEC command."""
+        return NECCommand(
+            address=0xFF00,
+            command=self.value,
+            repeat_count=repeat_count,
+        )

--- a/infrared_protocols/codes/generic/led/generic_13_key.py
+++ b/infrared_protocols/codes/generic/led/generic_13_key.py
@@ -1,12 +1,11 @@
 """Command codes for generic 13-key LED remote control."""
 
-from enum import IntEnum
-
 from ....commands import Command
 from ....commands.nec import NECCommand
+from .base import BaseGenericLEDCode
 
 
-class Generic13KeyCode(IntEnum):
+class Generic13KeyCode(BaseGenericLEDCode):
     """Generic 13-key LED remote control IR command codes."""
 
     ON = 0x45

--- a/infrared_protocols/codes/generic/led/generic_24_key.py
+++ b/infrared_protocols/codes/generic/led/generic_24_key.py
@@ -1,12 +1,11 @@
 """Command codes for generic 24-key LED remote control."""
 
-from enum import IntEnum
-
 from ....commands import Command
 from ....commands.nec import NECCommand
+from .base import BaseGenericLEDCode
 
 
-class Generic24KeyCode(IntEnum):
+class Generic24KeyCode(BaseGenericLEDCode):
     """Generic 24-key LED remote control IR command codes."""
 
     ON = 0x03

--- a/infrared_protocols/codes/generic/led/generic_40_key.py
+++ b/infrared_protocols/codes/generic/led/generic_40_key.py
@@ -1,12 +1,11 @@
 """Command codes for generic 40-key LED remote control."""
 
-from enum import IntEnum
-
 from ....commands import Command
 from ....commands.nec import NECCommand
+from .base import BaseGenericLEDCode
 
 
-class Generic40KeyCode(IntEnum):
+class Generic40KeyCode(BaseGenericLEDCode):
     """Generic 40-key LED remote control IR command codes."""
 
     ON = 0x40

--- a/infrared_protocols/codes/generic/led/generic_44_key.py
+++ b/infrared_protocols/codes/generic/led/generic_44_key.py
@@ -1,12 +1,11 @@
 """Command codes for generic 44-key LED remote control."""
 
-from enum import IntEnum
-
 from ....commands import Command
 from ....commands.nec import NECCommand
+from .base import BaseGenericLEDCode
 
 
-class Generic44KeyCode(IntEnum):
+class Generic44KeyCode(BaseGenericLEDCode):
     """Generic 44-key LED remote control IR command codes."""
 
     ON = 0x40


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Adds codes for generic 10-key LED candle remotes. 

Related: #118 

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/178041

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
