### PR TITLE
Add Persang speaker IR command codes

### DIFF
--- a/infrared_protocols/codes/persang/speaker.py
+++ b/infrared_protocols/codes/persang/speaker.py
@@ -1,0 +1,45 @@
+"""Command codes for Persang speakers.
+
+Captured from the remote shipped with a Persang Octane 9. Persang sells the same
+handset as a spare for its other Bluetooth speakers, so other models are likely
+to share these codes, but only the Octane 9 has been verified.
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+PERSANG_ADDRESS = 0x80
+
+
+class PersangSpeakerCode(IntEnum):
+    """Persang speaker IR command codes."""
+
+    EQ = 0x09
+    MODE = 0x1A
+    MUTE = 0x1E
+    NEXT = 0x03
+    NUM_0 = 0x07
+    NUM_1 = 0x0A
+    NUM_2 = 0x1B
+    NUM_3 = 0x1F
+    NUM_4 = 0x0C
+    NUM_5 = 0x0D
+    NUM_6 = 0x0E
+    NUM_7 = 0x00
+    NUM_8 = 0x0F
+    NUM_9 = 0x19
+    PLAY_PAUSE = 0x01
+    POWER = 0x12
+    PREVIOUS = 0x02
+    REPEAT = 0x08
+    SCAN = 0x04
+    VOLUME_DOWN = 0x05
+    VOLUME_UP = 0x06
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NEC command for this Persang speaker code."""
+        return NECCommand(
+            address=PERSANG_ADDRESS, command=self.value, repeat_count=repeat_count
+        )


### PR DESCRIPTION
## Proposed change

Adds the IR command codes for Persang speakers, used by the new `persang_infrared` integration in the linked core PR.

The codes were captured from the remote shipped with a Persang Octane 9. Nothing exists for this brand in Flipper-IRDB, irdb, SmartIR or IRremoteESP8266, so every value comes off the physical remote.

The remote is standard NEC, so no new command encoder is needed, only a code table:

| Property | Measured | NEC nominal |
|---|---|---|
| Leader | 9062 / 4406 µs | 9000 / 4500 |
| Bit mark | 621 µs mean | 562 |
| Zero / one space | 532 / 1625 µs | 562 / 1687 |
| Data bits | 32 | 32 |
| Address | `0x80`, inverted `0x7F` | addr + ~addr |
| Repeat | 4-timing repeat bursts at ~108 ms while held | 9000/2250/562 |

Each of the 21 buttons was captured twice, and both rounds agree. All 44 recorded frames decode back to the enum through `NECCommand.from_raw_timings`, and `PersangSpeakerCode.POWER.to_command().get_raw_timings()` reproduces the captured power frame to within 106 µs on the worst edge, round-tripping to `address=0x7F80 command=0x12`.

Persang sells the same handset as a spare part for several of its speakers, so other models are likely to share these codes, but only the Octane 9 has been verified, and the docstring says so.

## Additional information

- Link to core pull request: https://github.com/home-assistant/core/pull/178107

## Checklist

- [x] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
