### PR TITLE
Add Edifier RC2.1B remote IR command codes

### DIFF
--- a/infrared_protocols/codes/edifier/models.py
+++ b/infrared_protocols/codes/edifier/models.py
@@ -19,6 +19,7 @@ class EdifierCommandSet(StrEnum):
     R2730DB = "r2730db"
     S360DB = "s360db"
     RC20G = "rc20g"
+    RC2_1B = "rc2_1b"
     S3000PRO = "s3000pro"
 
 
@@ -48,6 +49,9 @@ class EdifierModel(StrEnum):
     RC31A = "RC31A"
     # RC20G command set (unique left/right volume controls)
     RC20G = "RC20G"
+    # RC2.1B command set
+    S530D = "S530D"
+    S730 = "S730"
     # S3000 Pro command set (RCA10B remote)
     S3000PRO = "S3000 Pro"
 
@@ -76,6 +80,9 @@ MODEL_TO_COMMAND_SET: dict[EdifierModel, EdifierCommandSet] = {
     EdifierModel.RC31A: EdifierCommandSet.S360DB,
     # RC20G command set
     EdifierModel.RC20G: EdifierCommandSet.RC20G,
+    # RC2.1B command set
+    EdifierModel.S530D: EdifierCommandSet.RC2_1B,
+    EdifierModel.S730: EdifierCommandSet.RC2_1B,
     # S3000 Pro command set
     EdifierModel.S3000PRO: EdifierCommandSet.S3000PRO,
 }

--- a/infrared_protocols/codes/edifier/rc2_1b.py
+++ b/infrared_protocols/codes/edifier/rc2_1b.py
@@ -1,0 +1,34 @@
+"""Command codes for the Edifier RC2.1B remote."""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.nec import NECCommand
+
+
+class EdifierRC21BCode(IntEnum):
+    """Edifier RC2.1B remote IR command codes."""
+
+    POWER = 0x46
+    MUTE = 0x41
+    VOLUME_UP_LEFT = 0x05
+    VOLUME_DOWN_LEFT = 0x47
+    VOLUME_UP_RIGHT = 0x06
+    VOLUME_DOWN_RIGHT = 0x49
+    BALL_L = 0x07
+    BALL_R = 0x5C
+    TREBLE_PLUS = 0x09
+    TREBLE_MINUS = 0x1E
+    BASS_PLUS = 0x45
+    BASS_MINUS = 0x5E
+    SUBWOOFER_PLUS = 0x03
+    SUBWOOFER_MINUS = 0x02
+    INPUT_CD = 0x58
+    INPUT_PC = 0x1A
+    INPUT_DIGITAL = 0x1B
+    LIGHT = 0x5B
+    ESC = 0x01
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build an NECCommand."""
+        return NECCommand(address=0x00, command=self.value, repeat_count=repeat_count)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->
Add codes for RC2.1B, as requested in #5 

I runtime tested this in locally in home assistant and it works as expected.

### Codes

| Key      | NEC Sequence | NEC command | Base64 RAW |
| --- | --- | --- | --- |
| MUTE      | 00 FF 82 7D | 00 41  | BSMjiBE4AuABAQJcAjjgAAHACwRcAnEGOKAD4AML4AUT4AEBAVwCgAMBOAJAI8ABQAvgBwMPOAJcAnEGOAJRoCMjtwg4Ag== | 
| POWER   | 00 FF 62 9D | 00 46 | BVEjihE1AoABAlkCNWABwAfgAQECdwZZIANAB8ADQA9AA4APATUC4AULADWgAUAfQAHAB0ABAncGWSADgAcPNQJZAncGNQJboFEjtgg1Ag==  | 
| VOLUME_DOWN_LEFT      | 00 FF E2 1D | 00 47 | BU4jiRE+AuAXAQFvBuAhA+ABAQF5AkA34AcBQBPAA0ABQAsPW6BOI78IPgL//04jvwg+Ag==  | 
| VOLUME_DOWN_RIGHT   | 00 FF 92 6D |  00 49  | Bk0jiBFbAjngAAFAC0AD4AUBAXYG4BkDwAFAKwE5AoBDgAuAAUALAXYG4AEXA3YGOQJAAUAHD06gTSPDCDkC//9NI8MIOQI=  | 
| VOLUME_UP_LEFT      | 00 FF A0 5F | 00 05 | B0UjeRFUAg8C4BUDAXAG4BkDQENAJ0AH4AsDwBtAB+AHAw9XoEUjwAhUAv//RSPACFQC  | 
| VOLUME_UP_RIGHT   | 00 FF 60 9F | 00 06 | BUsjiBE9AuAXAQF1BuAVA0ABwCPgCwFAG8ABQAvgBwMHqqBLI7cIPQI=  | 
| BALL_L      | 00 FF E0 1F |  00 07 | BSsjcRE+AuAXAQFxBuAhA+AXAeALSw+loCsjwQg+Av//KyPBCD4C  | 
| BALL_R   | 00 FF 3A C5 |  00 5C   | CiIjohE8AjwCXwI84BIBAXQG4BUDwAHgAydAAUAPQAFAB0AD4AMBwA8LdAY8AmSgIiOsCDwC  | 
| TREBLE_PLUS      | 00 FF 90 6F | 00 09 | CU0jeBE0AjQCXgKAA8ABQA9AAYAHAXUGQAMAXiAHQANAC+AHAwJeAjRgAQVeAnUGNALgAQECXgI0oAFAF0ADQAFABwJ1Bl4gA4AHD5GgTSO6CDQC//9NI7oIXgI=  | 
| TREBLE_MINUS   | 00 FF 78 87 | 00 1E  | BUcjnRE6AuANAQJdAjqgAQJxBl0gA0AHQAPgAwuADwA6IAGAC+ABB+ADAUAX4AUBAV0CQBPAAwemoEcjxghdAg==  | 
| BASS_PLUS      | 00 FF A2 5D | 00 45  | BTcjbRE8AuAXAQFyBsADAF3gAgvAE0AHAl0CPCABA3IGPALgAwHgAw/AC0AHwAMPPAJdAnIGPAKkoDcjtgg8Ag==  | 
| BASS_MINUS   | 00 FF 7A 85 | 00 5E | BU0jiBE8AuAXAQF2BsADAGLgAgvAEwE8AkABQAfgAwNAAUAPQAHAB+ADAcATC3YGPALboE0jtgg8Ag==  | 
| SUBWOOFER_PLUS      | 00 FF C0 3F | 00 03  | BTcjehE9AoABAl8CPeAOAQFzBuAdA+AXAeAPRw+KoDcjwwg9Av//NyPDCD0C  | 
| SUBWOOFER_MINUS   | 00 FF 40 BF | 00 02  | BU8jexE8AuARAQJdAjwgAQFyBuAVA0ABQCPgDwHAG0AH4AEDAF3gAAsPqaBPI7MIPAL//08jswhdAg== | 
| INPUT_CD      | 00 FF 1A E5 |  00 58 | BSkjdBE8AuAXAQF1BuAVA+ADAcArQAEEdQZcAjwgAQF1BuABA8ABQBNAAQt1BjwCjKApI6wIPAI=  | 
| INPUT_PC      | 00 FF 58 A7 | 00 1A  | BRgjchE5AoABAl4COeAOAQFxBkADAF6gB+AHCwE5AkABgAfgASMDOQJeAoADATkCgBsBOQLAB0ABAnEGXiADQAcJOQKloBgjtwg5Ag==  | 
| LIGHT      | 00 FF DA 25 | 00 5B | BRcjkRE8AuAXAQF0BuAdA0ABwCtAAUALBDwCXQI8oAGAD4ABwAsLdAY8As+gFyO6CDwC  | 
| ESC      | 00 FF 80 7F | 00 01 | CkQjnRE6AjoCYAI64AgB4AETAXMGwAMAYOACC8ATgAfgFwHAJ+ALBweSoEQjzwg6Ag==  | 
| INPUT_DIGITAL      | 00 FF D8 27 | 00 1B   | BVAjkRE8AuAXAQJxBlsgA0AH4BUDQAHAI+ABAQJbAjygAUAbwAFACwJxBlsgAwk8AnKgUCO7CDwC  | 

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: <!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) --> PR not created, but diff: https://github.com/home-assistant/core/compare/dev...flubshi:homeassistant-core:edifier_rc21b

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [ ] Tests pass (`pytest`).

Closes #5 .
