### PR TITLE
Add RC-6 mode 0 support and Philips TV codes

### DIFF
--- a/infrared_protocols/codes/philips/tv.py
+++ b/infrared_protocols/codes/philips/tv.py
@@ -1,0 +1,78 @@
+"""Command codes for Philips TVs."""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.rc6 import RC6Command
+
+PHILIPS_TV_ADDRESS = 0x00
+
+
+class PhilipsTVCode(IntEnum):
+    """Philips TV IR command codes."""
+
+    POWER = 0x0C
+    MUTE = 0x0D
+    VOLUME_UP = 0x10
+    VOLUME_DOWN = 0x11
+
+    NUM_0 = 0x00
+    NUM_1 = 0x01
+    NUM_2 = 0x02
+    NUM_3 = 0x03
+    NUM_4 = 0x04
+    NUM_5 = 0x05
+    NUM_6 = 0x06
+    NUM_7 = 0x07
+    NUM_8 = 0x08
+    NUM_9 = 0x09
+
+    CHANNEL_UP = 0x20
+    CHANNEL_DOWN = 0x21
+
+    NAV_UP = 0x58
+    NAV_DOWN = 0x59
+    NAV_LEFT = 0x5A
+    NAV_RIGHT = 0x5B
+    OK = 0x5C
+    BACK = 0x0A
+    HOME = 0x54
+    OPTIONS = 0x40
+
+    PLAY = 0x2C
+    PAUSE = 0x30
+    STOP = 0x31
+    RECORD = 0x37
+    REWIND = 0x2B
+    FAST_FORWARD = 0x28
+
+    SOURCE = 0x38
+    INFO = 0x0F
+    GUIDE = 0xCC
+    TEXT = 0x3C
+    SUBTITLE = 0x4B
+    FORMAT = 0xF5
+    SETTINGS = 0xBF
+    AMBILIGHT = 0x8F
+
+    RED = 0x6D
+    GREEN = 0x6E
+    YELLOW = 0x6F
+    BLUE = 0x70
+
+    NETFLIX = 0x76
+    YOUTUBE = 0x79
+    PRIME_VIDEO = 0xBA
+
+    def to_command(self, repeat_count: int = 0, *, toggle: int = 0) -> Command:
+        """Build an RC-6 command for this Philips TV code.
+
+        Flip ``toggle`` between successive presses of the same key, otherwise
+        the TV reads the second press as a repeat of the first and ignores it.
+        """
+        return RC6Command(
+            address=PHILIPS_TV_ADDRESS,
+            command=self.value,
+            toggle=toggle,
+            repeat_count=repeat_count,
+        )

--- a/infrared_protocols/commands/rc6.py
+++ b/infrared_protocols/commands/rc6.py
@@ -1,0 +1,131 @@
+"""RC-6 IR command (Philips, Microsoft MCE, and other devices)."""
+
+from typing import override
+
+from . import Command
+
+# RC-6 timing unit in microseconds: 16 carrier periods at 36 kHz. A normal bit
+# spans two units, the trailer bit four, so its halves are double width.
+RC6_UNIT_US = 444
+# RC-6 carrier frequency in Hz.
+RC6_MODULATION_HZ = 36000
+# Leader: a 6 unit burst followed by a 2 unit space, opening every frame.
+RC6_LEADER_MARK_US = 6 * RC6_UNIT_US
+RC6_LEADER_SPACE_US = 2 * RC6_UNIT_US
+# Time between the start of one frame and the start of the next while a key is
+# held. The 6 unit signal-free time that closes a frame is only a minimum; the
+# frame is padded out to this period.
+RC6_REPEAT_PERIOD_US = 107000
+# Mode 0 is the only mode in general consumer use, and its mode bits are zero.
+RC6_MODE_0_BITS = (0, 0, 0)
+
+
+def append_signed_us(timings: list[int], value: int) -> None:
+    """Append a microsecond duration, merging into the last entry if same sign."""
+    if timings and (timings[-1] > 0) == (value > 0):
+        timings[-1] += value
+    else:
+        timings.append(value)
+
+
+def manchester_encode_bit(timings: list[int], bit: int, half_bit_us: int) -> None:
+    """Append the two Manchester half-bits for ``bit`` to ``timings``.
+
+    RC-6 inverts the RC-5 convention: logic '1' is a burst followed by a
+    space, logic '0' is a space followed by a burst. Adjacent halves of
+    equal sign are merged.
+    """
+    if bit:
+        append_signed_us(timings, half_bit_us)
+        append_signed_us(timings, -half_bit_us)
+    else:
+        append_signed_us(timings, -half_bit_us)
+        append_signed_us(timings, half_bit_us)
+
+
+class RC6Command(Command):
+    """RC-6 mode 0 IR command (Philips, Microsoft MCE, and similar devices).
+
+    This is the protocol used by Philips televisions, by Windows Media Center
+    remotes, and by set-top boxes from operators such as Comcast/Xfinity.
+
+    Only mode 0, the 8-bit address / 8-bit command variant in general
+    consumer use, is supported. The longer-address RC-6A modes are a
+    separate protocol and are not encoded here.
+    """
+
+    address: int
+    command: int
+    toggle: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        toggle: int = 0,
+        modulation: int = RC6_MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the RC-6 IR command."""
+        if not 0 <= address <= 0xFF:
+            raise ValueError("RC-6 address must be in range 0x00..0xFF")
+        if not 0 <= command <= 0xFF:
+            raise ValueError("RC-6 command must be in range 0x00..0xFF")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.toggle = toggle
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the RC-6 command.
+
+        RC-6 mode 0 protocol timing (in microseconds):
+        - Carrier: 36 kHz
+        - Unit time: 444µs; normal bit 888µs, trailer bit 1776µs
+        - Leader: 2664µs burst, 888µs space
+        - Frame: start bit (always 1), 3 mode bits (000 for mode 0),
+          trailer bit carrying the toggle, address (8 bits, MSB first),
+          command (8 bits, MSB first)
+        - Logical '1': burst in first half of bit time (high then low)
+        - Logical '0': burst in second half of bit time (low then high)
+        - Total frame duration: 23088µs
+        - Signal-free time: at least 2664µs before the next frame may start
+        - Repeat period: 107ms (key still pressed)
+
+        The trailer bit is twice as wide as a normal bit, which is what
+        distinguishes it in a captured frame.
+        """
+        frame: list[int] = [RC6_LEADER_MARK_US, -RC6_LEADER_SPACE_US]
+
+        manchester_encode_bit(frame, 1, RC6_UNIT_US)
+        for mode_bit in RC6_MODE_0_BITS:
+            manchester_encode_bit(frame, mode_bit, RC6_UNIT_US)
+
+        manchester_encode_bit(frame, self.toggle & 1, 2 * RC6_UNIT_US)
+
+        for i in range(7, -1, -1):
+            manchester_encode_bit(frame, (self.address >> i) & 1, RC6_UNIT_US)
+        for i in range(7, -1, -1):
+            manchester_encode_bit(frame, (self.command >> i) & 1, RC6_UNIT_US)
+
+        # A frame ending on logic '1' closes with a space half-bit, which is
+        # indistinguishable from the signal-free time that follows it. Drop it
+        # to keep a pulse-bracketed timing list.
+        if frame[-1] < 0:
+            frame.pop()
+
+        timings = list(frame)
+
+        # Repeats are the same frame retransmitted every 107ms while the key
+        # remains pressed. The toggle bit only flips between distinct key
+        # presses, so it stays constant across repeats.
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in frame)
+            gap = RC6_REPEAT_PERIOD_US - frame_duration
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(frame)
+
+        return timings

--- a/tests/codes/test_philips_tv.py
+++ b/tests/codes/test_philips_tv.py
@@ -10,9 +10,12 @@ def test_philips_tv_codes_are_unique() -> None:
     """Every code must be distinct.
 
     ``IntEnum`` silently aliases duplicate values, so a transcription slip
-    would otherwise turn two buttons into one without failing anything.
+    would otherwise turn two buttons into one without failing anything. The
+    check has to go through ``__members__``, because iterating the enum
+    itself already hides aliases and would compare equal either way.
     """
-    assert len(PhilipsTVCode) == len(set(PhilipsTVCode))
+    members = PhilipsTVCode.__members__
+    assert len(members) == len(set(members.values()))
 
 
 @pytest.mark.parametrize(

--- a/tests/codes/test_philips_tv.py
+++ b/tests/codes/test_philips_tv.py
@@ -36,9 +36,12 @@ def test_philips_tv_code_matches_captured_remote(
     assert isinstance(command, RC6Command)
     assert command.address == 0x00
     assert command.command == expected_command
-    assert command.get_raw_timings() == RC6Command(
-        address=0x00, command=expected_command, toggle=1
-    ).get_raw_timings()
+    assert (
+        command.get_raw_timings()
+        == RC6Command(
+            address=0x00, command=expected_command, toggle=1
+        ).get_raw_timings()
+    )
 
 
 def test_philips_tv_code_to_command_defaults() -> None:

--- a/tests/codes/test_philips_tv.py
+++ b/tests/codes/test_philips_tv.py
@@ -1,0 +1,62 @@
+"""Tests for the Philips TV command codes."""
+
+import pytest
+
+from infrared_protocols.codes.philips.tv import PhilipsTVCode
+from infrared_protocols.commands.rc6 import RC6Command
+
+
+def test_philips_tv_codes_are_unique() -> None:
+    """Every code must be distinct.
+
+    ``IntEnum`` silently aliases duplicate values, so a transcription slip
+    would otherwise turn two buttons into one without failing anything.
+    """
+    assert len(PhilipsTVCode) == len(set(PhilipsTVCode))
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_command"),
+    [
+        pytest.param(PhilipsTVCode.PLAY, 0x2C, id="play"),
+        pytest.param(PhilipsTVCode.STOP, 0x31, id="stop"),
+        pytest.param(PhilipsTVCode.RECORD, 0x37, id="record"),
+        pytest.param(PhilipsTVCode.INFO, 0x0F, id="info"),
+    ],
+)
+def test_philips_tv_code_matches_captured_remote(
+    code: PhilipsTVCode, expected_command: int
+) -> None:
+    """Codes cross-checked against a captured Philips remote must round-trip.
+
+    These four are the buttons whose raw captures were used to verify the
+    RC-6 encoder itself.
+    """
+    command = code.to_command(toggle=1)
+    assert isinstance(command, RC6Command)
+    assert command.address == 0x00
+    assert command.command == expected_command
+    assert command.get_raw_timings() == RC6Command(
+        address=0x00, command=expected_command, toggle=1
+    ).get_raw_timings()
+
+
+def test_philips_tv_code_to_command_defaults() -> None:
+    """A code with no arguments must build a single unrepeated RC-6 frame."""
+    command = PhilipsTVCode.POWER.to_command()
+    assert isinstance(command, RC6Command)
+    assert command.address == 0x00
+    assert command.command == 0x0C
+    assert command.toggle == 0
+    assert command.repeat_count == 0
+    assert command.modulation == 36000
+
+
+def test_philips_tv_code_to_command_passes_through_toggle_and_repeats() -> None:
+    """Toggle and repeat count must reach the encoded frame."""
+    command = PhilipsTVCode.VOLUME_UP.to_command(2, toggle=1)
+    assert isinstance(command, RC6Command)
+    assert command.toggle == 1
+    assert command.repeat_count == 2
+    # Three frames in total: the initial one plus two repeats.
+    assert command.get_raw_timings().count(2664) == 3

--- a/tests/commands/test_rc6.py
+++ b/tests/commands/test_rc6.py
@@ -1,0 +1,146 @@
+"""Tests for the RC-6 IR command encoder."""
+
+import pytest
+
+from infrared_protocols.commands.rc6 import RC6Command
+
+# A Philips TV play press: address 0x00, command 0x2C, toggle set. Verified
+# against a real capture of a Philips universal remote, which agrees on every
+# edge to within receiver jitter.
+#
+# Frame layout, in order: leader, start bit (1), three mode bits (000), the
+# double-width trailer bit carrying the toggle, then address and command, both
+# 8 bits MSB first. Field boundaries do not line up with entry boundaries,
+# because adjacent Manchester halves of equal sign merge into one entry.
+PHILIPS_PLAY_TIMINGS: list[int] = [
+    2664, -888, 444, -888, 444, -444, 444, -444, 1332, -1332,
+    444, -444, 444, -444, 444, -444, 444, -444, 444, -444,
+    444, -444, 444, -444, 444, -444, 444, -444, 888, -888,
+    888, -444, 444, -888, 444, -444, 444,
+]  # fmt: skip
+
+# Every RC-6 mode 0 frame occupies the same 23088µs regardless of its payload.
+RC6_FRAME_DURATION_US = 23088
+# A frame whose last bit is logic '1' ends on a space half-bit, which is dropped
+# because the signal-free time that follows swallows it.
+RC6_TRAILING_SPACE_US = 444
+
+
+def test_rc6_command_get_raw_timings_philips_play() -> None:
+    """Test RC-6 timings for a Philips TV play press.
+
+    Philips televisions use RC-6 mode 0 with address 0x00. Command 0x2C is
+    play, and this frame was cross-checked against a real remote capture.
+    """
+    command = RC6Command(address=0x00, command=0x2C, toggle=1, repeat_count=0)
+    assert command.get_raw_timings() == PHILIPS_PLAY_TIMINGS
+    assert command.modulation == 36000
+
+
+def test_rc6_command_get_raw_timings_philips_play_with_repeat() -> None:
+    """Test that a repeated frame is spaced on the 107ms RC-6 period.
+
+    The captured remote sends two frames per press, separated by ~84ms, which
+    is the 107ms period minus the 23088µs frame.
+    """
+    command = RC6Command(address=0x00, command=0x2C, toggle=1, repeat_count=1)
+    assert command.get_raw_timings() == [
+        *PHILIPS_PLAY_TIMINGS,
+        -83912,
+        *PHILIPS_PLAY_TIMINGS,
+    ]
+
+
+def test_rc6_command_get_raw_timings_zero_address_zero_command() -> None:
+    """Test RC-6 timings for the all-zero address/command edge case.
+
+    With every payload bit zero, each bit contributes a space then a burst, so
+    the frame is a long run of merged 444µs halves.
+    """
+    expected_raw_timings = [
+        2664, -888, 444, -888, 444, -444, 444, -444, 444, -888,
+        888, -444, 444, -444, 444, -444, 444, -444, 444, -444,
+        444, -444, 444, -444, 444, -444, 444, -444, 444, -444,
+        444, -444, 444, -444, 444, -444, 444, -444, 444, -444,
+        444, -444, 444,
+    ]  # fmt: skip
+    command = RC6Command(address=0x00, command=0x00, toggle=0, repeat_count=0)
+    assert command.get_raw_timings() == expected_raw_timings
+
+
+@pytest.mark.parametrize(
+    ("toggle", "expected_trailer"),
+    [
+        pytest.param(0, [-888, 888], id="toggle_clear"),
+        pytest.param(1, [-1332, 444], id="toggle_set"),
+    ],
+)
+def test_rc6_command_trailer_bit_is_double_width(
+    toggle: int, expected_trailer: list[int]
+) -> None:
+    """The trailer bit spans four units, twice a normal bit.
+
+    A set toggle puts its burst first, so it merges with the preceding mode
+    bit's burst into 1332µs (444 + 888). A clear toggle puts its space first,
+    giving an 888µs space followed by an 888µs burst.
+    """
+    timings = RC6Command(address=0x00, command=0x00, toggle=toggle).get_raw_timings()
+    assert timings[9:11] == expected_trailer
+
+
+@pytest.mark.parametrize(
+    ("address", "command", "expected_duration"),
+    [
+        pytest.param(0x00, 0x00, RC6_FRAME_DURATION_US, id="last_bit_clear"),
+        pytest.param(0x00, 0x2C, RC6_FRAME_DURATION_US, id="last_bit_clear_mixed"),
+        pytest.param(
+            0xFF,
+            0xFF,
+            RC6_FRAME_DURATION_US - RC6_TRAILING_SPACE_US,
+            id="last_bit_set_all_ones",
+        ),
+        pytest.param(
+            0x00,
+            0x0F,
+            RC6_FRAME_DURATION_US - RC6_TRAILING_SPACE_US,
+            id="last_bit_set",
+        ),
+    ],
+)
+def test_rc6_command_frame_duration(
+    address: int, command: int, expected_duration: int
+) -> None:
+    """A frame always spans 23088µs, less the dropped trailing space if any."""
+    timings = RC6Command(address=address, command=command).get_raw_timings()
+    assert sum(abs(t) for t in timings) == expected_duration
+
+
+def test_rc6_command_toggle_changes_frame_but_not_duration() -> None:
+    """Flipping the toggle must change the frame while preserving its length."""
+    toggle_clear = RC6Command(address=0x04, command=0x0C, toggle=0).get_raw_timings()
+    toggle_set = RC6Command(address=0x04, command=0x0C, toggle=1).get_raw_timings()
+    assert toggle_clear != toggle_set
+    assert sum(abs(t) for t in toggle_clear) == sum(abs(t) for t in toggle_set)
+
+
+def test_rc6_command_address_and_command_are_distinct_fields() -> None:
+    """Swapping address and command must produce a different frame."""
+    assert (
+        RC6Command(address=0x12, command=0x34).get_raw_timings()
+        != RC6Command(address=0x34, command=0x12).get_raw_timings()
+    )
+
+
+@pytest.mark.parametrize(
+    ("address", "command"),
+    [
+        (-1, 0x00),
+        (0x100, 0x00),
+        (0x00, -1),
+        (0x00, 0x100),
+    ],
+)
+def test_rc6_command_rejects_out_of_range(address: int, command: int) -> None:
+    """RC-6 mode 0 fields are both 8-bit — anything else is invalid."""
+    with pytest.raises(ValueError):
+        RC6Command(address=address, command=command, toggle=0)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Adds RC-6 mode 0 support, in two commits: the protocol encoder, then a Philips TV codes module that consumes it.

RC-6 is used by Philips televisions, by Windows Media Center remotes, and by set-top boxes from operators such as Comcast/Xfinity. It was the largest protocol gap in the library: no supported protocol reaches those devices today.

**`RC6Command`** covers mode 0 only, the 8-bit address / 8-bit command variant in general consumer use. The longer-address RC-6A modes are a separate protocol and are not encoded here. Like `RC5Command`, this is encode only.

Two things make RC-6 more than a re-parameterised RC-5, and both are handled:

- The Manchester polarity is inverted. RC-5 puts the burst in the first half of the bit time for logic `0`; RC-6 puts it there for logic `1`.
- The trailer bit that carries the toggle spans four units instead of two. Its double-width halves merge with their neighbours differently, so the number of entries in the returned timing list varies with the payload: 37 for command `0x2C`, 41 for `0x0F`, 43 for `0x00`.

**`PhilipsTVCode`** adds 45 codes on RC-6 address `0x00`, covering power, volume, digits, channel, navigation, transport, the colour keys, and the Philips-specific Ambilight key. Its `to_command(repeat_count=0, *, toggle=0)` signature follows `MarantzAudioCode`, the existing precedent for a toggle-carrying protocol.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: <!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) --> None yet, deliberately.

### How the encoder was verified

Against raw captures of a Philips universal remote rather than against the specification alone. Decoding those captures independently yielded canonical Philips codes (play `0x2C`, stop `0x31`, record `0x37`, info `0x0F` at address `0x00`), and re-encoding them reproduces the captures:

```
Stop     entries= 75  max frame dev= 140us  gap: capture=84222 encoder=84356
Record   entries= 75  max frame dev= 140us  gap: capture=84194 encoder=84356
Play     entries= 75  max frame dev= 141us  gap: capture=83754 encoder=83912
Info     entries= 83  max frame dev= 146us  gap: capture=84219 encoder=84356
```

Entry counts match exactly. The remaining deviation is around 140µs on a 444µs unit, which is receiver jitter; the capture's own unit wobbles between 476µs and 484µs for a nominal 444µs. Note that `Play` shows a gap 444µs shorter than the other three in both the capture and the encoder, which confirms the handling of the trailing space half-bit on frames ending in a logic `1`.

The 107ms repeat period was measured from those captures (106.85ms) and then found to agree with the `^107m` frame period in the RC-6 definition in `IrpProtocols.xml`.

### How the codes were verified

Every value was cross-checked against 22 independent Philips and Xfinity remotes. The majority button name agrees with the enum name for all 45 entries, for example `0x0C` power (17 of 20), `0x0D` mute (20 of 20), `0x58` up (14 of 15), `0x8F` ambilight (3 of 3). The four capture-verified codes land where they should, so the path from capture to decode to enum to re-encode is closed.

Three things worth a reviewer's attention:

- `YOUTUBE` (`0x79`) and `PRIME_VIDEO` (`0xBA`) rest on two remotes each. Naming is unanimous within those, but they are the weakest entries; everything else has three or more and most have ten or more.
- 17 codes seen in the wild are deliberately left out because they are single-source or the remotes disagree on meaning: `0x12 0x13 0x22 0x41 0x4C 0x4D 0x57 0x5D 0x74 0x90 0x9F 0xB3 0xB4 0xBE 0xD2 0xF3 0xF4`. The instructive ones are `0x4C`/`0x4D`, which three remotes call channel up/down while six others assign that to `0x20`/`0x21`, and `0x90`, which appears as adjust, iii, and right.
- `tests/codes/` is a new directory; no codes module has tests today. The uniqueness test is the reason it is here: `IntEnum` silently aliases duplicate values, so a transcription slip in 45 hex literals would merge two buttons without failing anything. Happy to drop it if codes modules should stay untested for consistency.

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
