### PR TITLE
Clarify when command encoders may expose repeat handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@
 
 ## Protocol Semantics
 
-- Do not add generic repeat (full frame copy) support to command encoders. Only protocols with a distinct/special repeat-code frame should expose repeat handling.
+- Only expose repeat handling when the protocol itself defines how a held key is transmitted: either a distinct repeat-code frame (NEC, Kaseikyo) or retransmission of the full frame on a fixed frame period (RC-5, RC-6, Samsung32).
+- Do not add a generic "send it N times" knob to an encoder whose protocol says nothing about repetition, and do not invent a frame period the protocol does not specify.
 
 ## Error Handling
 


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Clarifies the protocol-semantics rule in `AGENTS.md` about repeat handling. Documentation only, no code changes.

The rule currently reads:

> Do not add generic repeat (full frame copy) support to command encoders. Only protocols with a distinct/special repeat-code frame should expose repeat handling.

Taken literally that forbids what three encoders in `main` already do:

| Encoder | Repeat style | Allowed by the old wording? |
| --- | --- | --- |
| `NECCommand` | distinct repeat-code frame | yes |
| `KaseikyoCommand` | distinct repeat-code frame | yes |
| `RC5Command` | full-frame retransmission | no |
| `MarantzExtendedCommand` | full-frame retransmission | no |
| `Samsung32Command` | full-frame retransmission | no |

RC-5 and Samsung32 have no repeat-code frame. Retransmitting the full frame on a fixed period is how those protocols express a held key, and IRP notation encodes that structurally: `RC5` is `(...)*` with `^114m`, and there is nothing generic or invented about it. So the wording is wrong about code that shipped a long time ago, independently of any new protocol.

The replacement names both legitimate shapes and keeps the original prohibition in a second bullet, so a generic "send it N times" knob on a protocol that says nothing about repetition, and an invented frame period, are both still ruled out.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: <!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) --> Not applicable, this changes contributor documentation only and has no public API surface.

Note that `CLAUDE.md` is a symlink to `AGENTS.md`, so it picks this up automatically.

Came up in review of #129, where the old wording was read as requiring `repeat_count` to be stripped from a new RC-6 encoder. Kept separate from that PR because the wording was already inaccurate about `main` regardless of RC-6.

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
