### PR TITLE
Add Pioneer protocol support and DVD player codes

### DIFF
--- a/infrared_protocols/codes/pioneer/dvd.py
+++ b/infrared_protocols/codes/pioneer/dvd.py
@@ -1,0 +1,98 @@
+"""Command codes for Pioneer DVD players.
+
+Codes are taken from the Pioneer VXX2914 remote. Power, the menu keys and
+audio are corroborated by other Pioneer remotes (CU-DV027, XXD3089), which
+suggests the set is shared across Pioneer DVD devices rather than specific to
+one player.
+"""
+
+from enum import Enum
+
+from ...commands import Command
+from ...commands.pioneer import PioneerCommand
+
+PIONEER_DVD_ADDRESS = 0xA3
+PIONEER_DVD_EXTENDED_ADDRESS = 0xAF
+# Sent as the preamble of a two-part command to reach the extended set. It is
+# itself a command in the 0xA3 set, alongside the transport keys.
+PIONEER_DVD_EXTENDED_SELECTOR = 0x99
+
+# Preamble and address shared by every extended code. Kept out of the enum
+# body, where a leading underscore is not enough to stop it becoming a member.
+_EXTENDED = (
+    PIONEER_DVD_ADDRESS,
+    PIONEER_DVD_EXTENDED_SELECTOR,
+    PIONEER_DVD_EXTENDED_ADDRESS,
+)
+
+
+class PioneerDVDCode(Enum):
+    """IR command code for a Pioneer DVD player.
+
+    The tuple value is one of:
+
+    - ``(address, command)`` — a single Pioneer frame.
+    - ``(preamble_address, preamble_command, address, command)`` — a two-part
+      command, whose preamble selects the extended command set.
+    """
+
+    STOP = (PIONEER_DVD_ADDRESS, 0x98)
+    NEXT = (PIONEER_DVD_ADDRESS, 0x9C)
+    PREVIOUS = (PIONEER_DVD_ADDRESS, 0x9D)
+    PLAY = (PIONEER_DVD_ADDRESS, 0x9E)
+    PAUSE = (PIONEER_DVD_ADDRESS, 0x9F)
+
+    POWER = (*_EXTENDED, 0xBC)
+    OPEN_CLOSE = (*_EXTENDED, 0xB6)
+
+    NUM_0 = (*_EXTENDED, 0xA0)
+    NUM_1 = (*_EXTENDED, 0xA1)
+    NUM_2 = (*_EXTENDED, 0xA2)
+    NUM_3 = (*_EXTENDED, 0xA3)
+    NUM_4 = (*_EXTENDED, 0xA4)
+    NUM_5 = (*_EXTENDED, 0xA5)
+    NUM_6 = (*_EXTENDED, 0xA6)
+    NUM_7 = (*_EXTENDED, 0xA7)
+    NUM_8 = (*_EXTENDED, 0xA8)
+    NUM_9 = (*_EXTENDED, 0xA9)
+
+    NAV_UP = (*_EXTENDED, 0xF2)
+    NAV_DOWN = (*_EXTENDED, 0xF3)
+    NAV_LEFT = (*_EXTENDED, 0x63)
+    NAV_RIGHT = (*_EXTENDED, 0x64)
+    ENTER = (*_EXTENDED, 0xEF)
+    RETURN = (*_EXTENDED, 0xF4)
+    MENU = (*_EXTENDED, 0xB9)
+    TOP_MENU = (*_EXTENDED, 0xB4)
+    HOME_MENU = (*_EXTENDED, 0xB0)
+
+    FORWARD = (*_EXTENDED, 0xE9)
+    REWIND = (*_EXTENDED, 0xEA)
+    PLAY_MODE = (*_EXTENDED, 0x7F)
+
+    AUDIO = (*_EXTENDED, 0xBE)
+    SUBTITLE = (*_EXTENDED, 0x36)
+    ANGLE = (*_EXTENDED, 0xB5)
+    SURROUND = (*_EXTENDED, 0x61)
+    ZOOM = (*_EXTENDED, 0x37)
+    DISPLAY = (*_EXTENDED, 0xE3)
+    CLEAR = (*_EXTENDED, 0xE5)
+
+    def to_command(self, repeat_count: int = 0) -> Command:
+        """Build the IR command for this Pioneer DVD code."""
+        if len(self.value) == 4:
+            preamble_address, preamble_command, address, command = self.value
+            return PioneerCommand(
+                address=address,
+                command=command,
+                preamble_address=preamble_address,
+                preamble_command=preamble_command,
+                repeat_count=repeat_count,
+            )
+
+        address, command = self.value
+        return PioneerCommand(
+            address=address,
+            command=command,
+            repeat_count=repeat_count,
+        )

--- a/infrared_protocols/commands/pioneer.py
+++ b/infrared_protocols/commands/pioneer.py
@@ -1,0 +1,101 @@
+"""Pioneer IR command."""
+
+from typing import override
+
+from . import Command
+from .nec import NECCommand
+
+# Pioneer carrier frequency in Hz. The frame is NEC-shaped, but Pioneer
+# modulates it at 40 kHz rather than NEC's 38 kHz.
+PIONEER_MODULATION_HZ = 40000
+# Time between the start of one frame and the start of the next. Measured
+# across captures of Pioneer remotes, which agree on this for both one-frame
+# and two-part commands.
+PIONEER_FRAME_PERIOD_US = 90000
+
+
+class PioneerCommand(Command):
+    """Pioneer IR command.
+
+    A Pioneer frame is a standard NEC frame with an 8-bit address, sent at a
+    40 kHz carrier on a 90ms frame period.
+
+    Many Pioneer devices reach a second command set through a two-part
+    command: a preamble frame that selects the set, followed by the frame
+    carrying the button. Pass ``preamble_address`` and ``preamble_command``
+    together to emit one. Devices that need no preamble send a single frame.
+    """
+
+    address: int
+    command: int
+    preamble_address: int | None
+    preamble_command: int | None
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        preamble_address: int | None = None,
+        preamble_command: int | None = None,
+        modulation: int = PIONEER_MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Pioneer IR command."""
+        if not 0 <= address <= 0xFF:
+            raise ValueError("Pioneer address must be in range 0x00..0xFF")
+        if not 0 <= command <= 0xFF:
+            raise ValueError("Pioneer command must be in range 0x00..0xFF")
+        if (preamble_address is None) != (preamble_command is None):
+            raise ValueError(
+                "preamble_address and preamble_command must be given together"
+            )
+        if preamble_address is not None and not 0 <= preamble_address <= 0xFF:
+            raise ValueError("Pioneer preamble_address must be in range 0x00..0xFF")
+        if preamble_command is not None and not 0 <= preamble_command <= 0xFF:
+            raise ValueError("Pioneer preamble_command must be in range 0x00..0xFF")
+
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.preamble_address = preamble_address
+        self.preamble_command = preamble_command
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Pioneer command.
+
+        Pioneer protocol timing (in microseconds):
+        - Carrier: 40 kHz
+        - Frame: a standard NEC frame, 8-bit address and its complement
+          followed by the 8-bit command and its complement, LSB first
+        - Frame period: 90000µs, so a frame is followed by idle space until
+          the next one starts
+
+        A two-part command sends its preamble frame first. Repeats resend the
+        whole command, preamble included, which is what Pioneer remotes do
+        while a key is held.
+        """
+        frames = []
+        if self.preamble_address is not None and self.preamble_command is not None:
+            frames.append(self._frame(self.preamble_address, self.preamble_command))
+        frames.append(self._frame(self.address, self.command))
+
+        timings: list[int] = []
+        previous_duration = 0
+        for frame in frames * (self.repeat_count + 1):
+            if timings:
+                timings.append(-(PIONEER_FRAME_PERIOD_US - previous_duration))
+            timings.extend(frame)
+            previous_duration = sum(abs(t) for t in frame)
+
+        return timings
+
+    @staticmethod
+    def _frame(address: int, command: int) -> list[int]:
+        """Build one Pioneer frame.
+
+        The frame is bit-for-bit an NEC frame; only the carrier and the frame
+        period differ, and both are handled by the caller.
+        """
+        return NECCommand(address=address, command=command).get_raw_timings()

--- a/tests/codes/test_pioneer_dvd.py
+++ b/tests/codes/test_pioneer_dvd.py
@@ -1,0 +1,88 @@
+"""Tests for the Pioneer DVD command codes."""
+
+import pytest
+
+from infrared_protocols.codes.pioneer.dvd import PioneerDVDCode
+from infrared_protocols.commands.pioneer import PioneerCommand
+
+# A Pioneer frame is 67 timing entries, and two frames are joined by one gap.
+FRAME_ENTRIES = 67
+TWO_PART_ENTRIES = 2 * FRAME_ENTRIES + 1
+
+
+def test_pioneer_dvd_codes_have_no_private_members() -> None:
+    """Helper values must not leak into the enum.
+
+    A name with a single leading underscore is not enough to keep it out of an
+    ``Enum``: only sunder and dunder names are excluded, so a shared tuple
+    prefix declared in the class body would become a member with the wrong
+    shape.
+    """
+    assert [name for name in PioneerDVDCode.__members__ if name.startswith("_")] == []
+
+
+def test_pioneer_dvd_codes_are_unique() -> None:
+    """Every code must be distinct, since duplicates become silent aliases."""
+    members = PioneerDVDCode.__members__
+    assert len(members) == len(set(members.values()))
+
+
+@pytest.mark.parametrize(
+    ("code", "address", "command"),
+    [
+        pytest.param(PioneerDVDCode.STOP, 0xA3, 0x98, id="stop"),
+        pytest.param(PioneerDVDCode.PLAY, 0xA3, 0x9E, id="play"),
+        pytest.param(PioneerDVDCode.PAUSE, 0xA3, 0x9F, id="pause"),
+    ],
+)
+def test_pioneer_dvd_transport_codes_are_single_frame(
+    code: PioneerDVDCode, address: int, command: int
+) -> None:
+    """Transport keys sit in the base command set and need no preamble."""
+    built = code.to_command()
+    assert isinstance(built, PioneerCommand)
+    assert built.preamble_address is None
+    assert built.preamble_command is None
+    assert built.get_raw_timings() == (
+        PioneerCommand(address=address, command=command).get_raw_timings()
+    )
+    assert len(built.get_raw_timings()) == FRAME_ENTRIES
+
+
+@pytest.mark.parametrize(
+    ("code", "command"),
+    [
+        pytest.param(PioneerDVDCode.POWER, 0xBC, id="power"),
+        pytest.param(PioneerDVDCode.NUM_0, 0xA0, id="num_0"),
+        pytest.param(PioneerDVDCode.MENU, 0xB9, id="menu"),
+    ],
+)
+def test_pioneer_dvd_extended_codes_are_two_part(
+    code: PioneerDVDCode, command: int
+) -> None:
+    """Extended keys prepend the preamble that selects their command set."""
+    built = code.to_command()
+    assert isinstance(built, PioneerCommand)
+    assert built.preamble_address == 0xA3
+    assert built.preamble_command == 0x99
+    assert built.address == 0xAF
+    assert built.command == command
+    assert len(built.get_raw_timings()) == TWO_PART_ENTRIES
+
+
+def test_pioneer_dvd_code_set_covers_both_shapes() -> None:
+    """The remote mixes both command shapes, so the enum must carry both."""
+    single = [code for code in PioneerDVDCode if len(code.value) == 2]
+    two_part = [code for code in PioneerDVDCode if len(code.value) == 4]
+    assert single
+    assert two_part
+    assert len(single) + len(two_part) == len(PioneerDVDCode)
+
+
+def test_pioneer_dvd_code_passes_through_repeat_count() -> None:
+    """Repeat count must reach the built command."""
+    built = PioneerDVDCode.POWER.to_command(2)
+    assert isinstance(built, PioneerCommand)
+    assert built.repeat_count == 2
+    # Three passes of a two-part command: six frames joined by five gaps.
+    assert len(built.get_raw_timings()) == 6 * FRAME_ENTRIES + 5

--- a/tests/commands/test_pioneer.py
+++ b/tests/commands/test_pioneer.py
@@ -1,0 +1,147 @@
+"""Tests for the Pioneer IR command encoder."""
+
+import pytest
+
+from infrared_protocols.commands.nec import NECCommand
+from infrared_protocols.commands.pioneer import (
+    PIONEER_FRAME_PERIOD_US,
+    PioneerCommand,
+)
+
+# An NEC frame, and therefore a Pioneer frame, is 67 timing entries.
+FRAME_ENTRIES = 67
+
+
+def _nec_frame(address: int, command: int) -> list[int]:
+    """Build the NEC frame a Pioneer frame is expected to match."""
+    return NECCommand(address=address, command=command).get_raw_timings()
+
+
+def test_pioneer_command_single_frame() -> None:
+    """A command without a preamble is one NEC frame at Pioneer's carrier.
+
+    Pioneer receivers such as the SX-Q180 address their buttons directly, with
+    no preamble frame.
+    """
+    command = PioneerCommand(address=0xA6, command=0x01)
+    timings = command.get_raw_timings()
+    assert timings == _nec_frame(0xA6, 0x01)
+    assert len(timings) == FRAME_ENTRIES
+    assert command.modulation == 40000
+
+
+def test_pioneer_command_two_part() -> None:
+    """A two-part command sends its preamble frame, a gap, then the button.
+
+    These values are a power press captured from a Pioneer CU-MJO11 MiniDisc
+    remote: preamble 0xA3/0x91 selects the command set, 0xAF/0x60 is power.
+    """
+    preamble_frame = _nec_frame(0xA3, 0x91)
+    command_frame = _nec_frame(0xAF, 0x60)
+    gap = PIONEER_FRAME_PERIOD_US - sum(abs(t) for t in preamble_frame)
+
+    command = PioneerCommand(
+        address=0xAF,
+        command=0x60,
+        preamble_address=0xA3,
+        preamble_command=0x91,
+    )
+    assert command.get_raw_timings() == [*preamble_frame, -gap, *command_frame]
+
+
+def test_pioneer_command_frame_period() -> None:
+    """Each frame plus the gap that follows it must span the frame period."""
+    timings = PioneerCommand(
+        address=0xAF,
+        command=0x60,
+        preamble_address=0xA3,
+        preamble_command=0x91,
+    ).get_raw_timings()
+    first_frame = timings[:FRAME_ENTRIES]
+    gap = timings[FRAME_ENTRIES]
+    assert sum(abs(t) for t in first_frame) + abs(gap) == PIONEER_FRAME_PERIOD_US
+
+
+def test_pioneer_command_repeat_resends_the_whole_command() -> None:
+    """Repeating a two-part command resends the preamble as well.
+
+    Captures of held keys show the preamble and button frames alternating,
+    not the button frame repeating on its own.
+    """
+    preamble_frame = _nec_frame(0xA3, 0x91)
+    timings = PioneerCommand(
+        address=0xAF,
+        command=0x60,
+        preamble_address=0xA3,
+        preamble_command=0x91,
+        repeat_count=1,
+    ).get_raw_timings()
+
+    # Four frames of 67 entries, separated by three gaps.
+    assert len(timings) == 4 * FRAME_ENTRIES + 3
+    assert timings[:FRAME_ENTRIES] == preamble_frame
+    third_frame_start = 2 * (FRAME_ENTRIES + 1)
+    assert timings[third_frame_start : third_frame_start + FRAME_ENTRIES] == (
+        preamble_frame
+    )
+
+
+def test_pioneer_command_repeat_without_preamble() -> None:
+    """Repeating a single-frame command resends just that frame."""
+    timings = PioneerCommand(
+        address=0xA6, command=0x01, repeat_count=2
+    ).get_raw_timings()
+    assert len(timings) == 3 * FRAME_ENTRIES + 2
+
+
+@pytest.mark.parametrize(
+    ("preamble_address", "preamble_command"),
+    [
+        pytest.param(0xA3, None, id="address_without_command"),
+        pytest.param(None, 0x91, id="command_without_address"),
+    ],
+)
+def test_pioneer_command_rejects_half_a_preamble(
+    preamble_address: int | None, preamble_command: int | None
+) -> None:
+    """A preamble needs both of its fields, since it is a whole frame."""
+    with pytest.raises(ValueError):
+        PioneerCommand(
+            address=0xAF,
+            command=0x60,
+            preamble_address=preamble_address,
+            preamble_command=preamble_command,
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs"),
+    [
+        pytest.param({"address": -1, "command": 0x00}, id="address_negative"),
+        pytest.param({"address": 0x100, "command": 0x00}, id="address_too_large"),
+        pytest.param({"address": 0xA6, "command": -1}, id="command_negative"),
+        pytest.param({"address": 0xA6, "command": 0x100}, id="command_too_large"),
+        pytest.param(
+            {
+                "address": 0xAF,
+                "command": 0x60,
+                "preamble_address": 0x100,
+                "preamble_command": 0x91,
+            },
+            id="preamble_address_too_large",
+        ),
+        pytest.param(
+            {
+                "address": 0xAF,
+                "command": 0x60,
+                "preamble_address": 0xA3,
+                "preamble_command": 0x100,
+            },
+            id="preamble_command_too_large",
+        ),
+    ],
+)
+def test_pioneer_command_rejects_out_of_range(kwargs: dict[str, int]) -> None:
+    """Pioneer addresses and commands are all 8-bit."""
+    with pytest.raises(ValueError):
+        PioneerCommand(**kwargs)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Adds Pioneer support, in two commits: the protocol encoder, then a Pioneer DVD codes module that consumes it.

**`PioneerCommand`.** A Pioneer frame is a standard NEC frame with an 8-bit address, sent at a 40 kHz carrier, so the encoder builds on `NECCommand` rather than duplicating the bit loop. That follows `panasonic_ac`, which builds on `KaseikyoCommand` the same way.

The part that needed new code is the two-part command. Many Pioneer devices reach a second command set through a preamble frame that selects the set, followed by the frame carrying the button:

```
Power      frame1=0xA3/0x91    frame2=0xAF/0x60
Random     frame1=0xA3/0x91    frame2=0xAF/0x7C
Hi-Lite    frame1=0xA3/0x91    frame2=0xAF/0x7E
```

Nothing in the library could express this. `repeat_count` resends the *same* frame, not a different one. Pass `preamble_address` and `preamble_command` together to emit a two-part command; devices that need no preamble send a single frame.

**`PioneerDVDCode`.** 36 codes from the Pioneer VXX2914 remote, which happens to exercise both shapes: the transport keys are single frames in the `0xA3` set, and everything else is a two-part command reaching the extended set at `0xAF`. Value tuples are either `(address, command)` or `(preamble_address, preamble_command, address, command)`, dispatched in `to_command`, following `MarantzAudioCode`.

A nice confirmation of the design: the preamble command `0x99` sits inside the transport range `0x98`–`0x9F` itself, so "select the extended set" is just another command in the base set.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: <!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) --> None yet, deliberately, as with #129.

### How the encoder was verified

Against all 265 multi-frame Pioneer captures available to me. Frame counts and entry counts match exactly on every one. Splitting the deviation by position in the timing list:

```
frame bit entries   n=47101  median=  62us  p95= 187us  max= 550us
inter-frame gaps    n=  438  median=3716us
total duration      n=  265  median=4379us
```

The frame bits are essentially exact. The gaps carry the difference because the captures run about 6% fast (unit ~532µs against the specified 564µs), so their frames are shorter and their gaps correspondingly longer while the frame period holds. The encoder emits specified timings, and the period is what the device actually gates on.

### Two details that follow the hardware, not the notation

Both are deliberate departures from the `Pioneer` and `Pioneer-2Part` definitions in `IrpProtocols.xml`, and both are worth a reviewer's eye:

- **Held keys resend the whole command, preamble included.** 66 captures show the two frames alternating (`ABAB`); none show the second frame repeating on its own (`ABB`). The IRP notation writes the repeat as `(frame2)+`, which implies the latter.
- **The frame period is 90ms for both shapes.** IRP gives single-frame `Pioneer` a 108ms period. Measured periods were a 90.13ms median across 139 single-code repeats, with all 139 in the 85 to 95ms band, and 89.53ms across 299 two-part gaps, with 297 of 299 in that band. One constant covers both.

### On the codes, and where the evidence is thin

Worth stating plainly, because I applied a stricter bar in #129 and this does not meet it. Per-command corroboration for this set:

```
 0xBC       3  power [CU-DV027,VXX2914]; dvd_power [XXD3089]
 0xB9       2  menu [VXX2914]; dvd__menu [XXD3089]
 0xB4       2  top_menu [VXX2914]; dvd__top_menu [XXD3089]
 0xBE       2  audio [VXX2914]; dvd_audio [XXD3089]
 0x36       2  subtitle [VXX2914]; dvd_sub_title [XXD3089]
 ... the remaining codes come from the VXX2914 alone
```

Power, the menu keys, audio and subtitle are corroborated by two other Pioneer remotes, which suggests the set is shared across Pioneer DVD devices rather than specific to one player. The rest rests on a single remote. That is acceptable here in a way it was not for `PhilipsTVCode`, because this module is scoped to a device class from one documented remote rather than claiming to be the union across a brand, which matches how `edifier/r1280db.py` and `nedis/vmat3462at.py` are scoped. The docstring names the source.

One entry to look at specifically: `NAV_LEFT` and `NAV_RIGHT` are `0x63`/`0x64` because that is how the remote labels them, but `NAV_UP` and `NAV_DOWN` are `0xF2`/`0xF3` and `0xF0`/`0xF1` are conspicuously absent from an otherwise contiguous cursor cluster. I suspect `0x63`/`0x64` may be audio channel rather than cursor keys, and I could not resolve it without the hardware.

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
