### PR TITLE
Add Proton protocol support and NEC display codes

### DIFF
--- a/infrared_protocols/codes/nec/display.py
+++ b/infrared_protocols/codes/nec/display.py
@@ -1,0 +1,78 @@
+"""Command codes for NEC displays.
+
+The same command set drives NEC projectors and televisions. Codes are taken
+from an RU-M124 projector remote; the power, standby, digit, navigation,
+volume, channel, menu and guide keys are confirmed against a second NEC
+television remote.
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.proton import ProtonCommand
+
+NEC_DISPLAY_ADDRESS = 0xF4
+
+
+class NECDisplayCode(IntEnum):
+    """NEC display IR command codes."""
+
+    POWER = 0x52
+    STANDBY = 0x4E
+    MUTE = 0x1B
+    VOLUME_UP = 0x17
+    VOLUME_DOWN = 0x16
+
+    NUM_0 = 0x12
+    NUM_1 = 0x08
+    NUM_2 = 0x09
+    NUM_3 = 0x0A
+    NUM_4 = 0x0B
+    NUM_5 = 0x0C
+    NUM_6 = 0x0D
+    NUM_7 = 0x0E
+    NUM_8 = 0x0F
+    NUM_9 = 0x10
+
+    CHANNEL_UP = 0x33
+    CHANNEL_DOWN = 0x32
+
+    NAV_UP = 0x15
+    NAV_DOWN = 0x14
+    NAV_LEFT = 0x22
+    NAV_RIGHT = 0x21
+    OK = 0x23
+    ENTER = 0x45
+    MENU = 0x20
+    EXIT = 0x1F
+    GUIDE = 0x34
+    OPTION = 0x39
+    OPTION_MENU = 0x56
+    DISPLAY = 0x19
+    TEXT = 0x2C
+
+    INPUT_VGA = 0x04
+    INPUT_DVI = 0x2D
+    INPUT_HDMI_1 = 0x64
+    INPUT_HDMI_2 = 0x58
+    INPUT_HDMI_3 = 0x59
+    INPUT_DISPLAYPORT_1 = 0x66
+    INPUT_DISPLAYPORT_2 = 0x67
+    INPUT_VIDEO = 0x53
+    INPUT_MEDIA_PLAYER = 0x68
+    INPUT_COMPUTE_MODULE = 0x69
+    AUDIO_INPUT = 0x1E
+
+    PICTURE_MODE = 0x1D
+    ASPECT_RATIO = 0x29
+    AUTO_SETUP = 0x1C
+    IMAGE_FLIP = 0x57
+    STILL = 0x27
+    CAPTURE = 0x28
+    MULTI_PICTURE = 0x24
+    ACTIVE_PICTURE = 0x5F
+    MTS = 0x1A
+
+    def to_command(self) -> Command:
+        """Build a Proton command for this NEC display code."""
+        return ProtonCommand(address=NEC_DISPLAY_ADDRESS, command=self.value)

--- a/infrared_protocols/commands/proton.py
+++ b/infrared_protocols/commands/proton.py
@@ -1,0 +1,131 @@
+"""Proton IR command protocol."""
+
+from typing import Self, override
+
+from . import Command
+
+# Proton timing unit in microseconds. Every other duration is a multiple of it.
+UNIT = 500
+LEADER_HIGH = 16 * UNIT
+LEADER_LOW = 8 * UNIT
+BIT_HIGH = UNIT
+ZERO_LOW = UNIT
+ONE_LOW = 3 * UNIT
+# The address and command halves are separated by a stop mark and a gap as long
+# as the leader's, which is what distinguishes this protocol from NEC.
+MID_FRAME_GAP = 8 * UNIT
+MODULATION_HZ = 38500
+TOLERANCE = 0.4
+
+
+class ProtonCommand(Command):
+    """Proton IR command.
+
+    Frame structure (LSB first throughout):
+    - Leader: 8000µs mark, 4000µs space
+    - 8 address bits: each 500µs mark + 500/1500µs space
+    - Mid-frame stop: 500µs mark, 4000µs space
+    - 8 command bits: each 500µs mark + 500/1500µs space
+    - Stop: 500µs mark
+
+    Used by NEC Display projectors and televisions, and by Proton and Audiovox
+    devices. ``GEACCommand`` builds the same frame shape, but numbers its bits
+    the other way round and uses a longer timing unit, so the two are not
+    interchangeable.
+    """
+
+    address: int
+    command: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        modulation: int = MODULATION_HZ,
+    ) -> None:
+        """Initialize the Proton IR command."""
+        if not 0 <= address <= 0xFF:
+            raise ValueError(f"address must be 0-255, got {address}")
+        if not 0 <= command <= 0xFF:
+            raise ValueError(f"command must be 0-255, got {command}")
+        super().__init__(modulation=modulation, repeat_count=0)
+        self.address = address
+        self.command = command
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Proton command."""
+        timings: list[int] = [LEADER_HIGH, -LEADER_LOW]
+
+        for i in range(8):
+            bit = (self.address >> i) & 1
+            timings.extend([BIT_HIGH, -(ONE_LOW if bit else ZERO_LOW)])
+
+        timings.extend([BIT_HIGH, -MID_FRAME_GAP])
+
+        for i in range(8):
+            bit = (self.command >> i) & 1
+            timings.extend([BIT_HIGH, -(ONE_LOW if bit else ZERO_LOW)])
+
+        timings.append(BIT_HIGH)
+
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a ProtonCommand.
+
+        Returns a ProtonCommand if the timings match, or None otherwise.
+        Minimum: leader (2) + 8 addr pairs (16) + mid-frame (2) + 8 cmd pairs (16)
+        + stop (1) = 37 timings.
+        """
+        if len(timings) < 37:
+            return None
+
+        if not cls._is_close(timings[0], LEADER_HIGH) or not cls._is_close(
+            -timings[1], LEADER_LOW
+        ):
+            return None
+
+        address = 0
+        for i in range(8):
+            bit = cls._decode_bit(timings[2 + 2 * i], -timings[3 + 2 * i])
+            if bit is None:
+                return None
+            address |= bit << i
+
+        # Validate mid-frame stop mark and gap
+        if not cls._is_close(timings[18], BIT_HIGH) or not cls._is_close(
+            -timings[19], MID_FRAME_GAP
+        ):
+            return None
+
+        command = 0
+        for i in range(8):
+            bit = cls._decode_bit(timings[20 + 2 * i], -timings[21 + 2 * i])
+            if bit is None:
+                return None
+            command |= bit << i
+
+        if not cls._is_close(timings[36], BIT_HIGH):
+            return None
+
+        return cls(address=address, command=command)
+
+    @staticmethod
+    def _is_close(actual: int, expected: int) -> bool:
+        """Check if an actual timing value is within tolerance of the expected value."""
+        margin = expected * TOLERANCE
+        return expected - margin <= actual <= expected + margin
+
+    @classmethod
+    def _decode_bit(cls, high_us: int, low_us: int) -> int | None:
+        """Decode a single Proton data bit from high and low timings."""
+        if not cls._is_close(high_us, BIT_HIGH):
+            return None
+        if cls._is_close(low_us, ZERO_LOW):
+            return 0
+        if cls._is_close(low_us, ONE_LOW):
+            return 1
+        return None

--- a/tests/codes/test_nec_display.py
+++ b/tests/codes/test_nec_display.py
@@ -1,0 +1,65 @@
+"""Tests for the NEC display command codes."""
+
+import pytest
+
+from infrared_protocols.codes.nec.display import (
+    NEC_DISPLAY_ADDRESS,
+    NECDisplayCode,
+)
+from infrared_protocols.commands.proton import ProtonCommand
+
+
+def test_nec_display_codes_are_unique() -> None:
+    """Every code must be distinct, since duplicates become silent aliases."""
+    members = NECDisplayCode.__members__
+    assert len(members) == len(set(members.values()))
+
+
+@pytest.mark.parametrize(
+    ("code", "command"),
+    [
+        pytest.param(NECDisplayCode.POWER, 0x52, id="power"),
+        pytest.param(NECDisplayCode.STANDBY, 0x4E, id="standby"),
+        pytest.param(NECDisplayCode.MUTE, 0x1B, id="mute"),
+        pytest.param(NECDisplayCode.INPUT_HDMI_1, 0x64, id="input_hdmi_1"),
+    ],
+)
+def test_nec_display_code_to_command(code: NECDisplayCode, command: int) -> None:
+    """Each code builds a Proton command on the NEC display address."""
+    built = code.to_command()
+    assert isinstance(built, ProtonCommand)
+    assert built.address == NEC_DISPLAY_ADDRESS
+    assert built.command == command
+    assert built.get_raw_timings() == (
+        ProtonCommand(address=NEC_DISPLAY_ADDRESS, command=command).get_raw_timings()
+    )
+
+
+def test_nec_display_digits_are_contiguous() -> None:
+    """Digits 1 through 9 occupy consecutive codes, with 0 just past them.
+
+    This is what confirmed the protocol sends its bits least significant first:
+    decoded the other way round, the digit keys scatter.
+    """
+    digits = [
+        NECDisplayCode.NUM_1,
+        NECDisplayCode.NUM_2,
+        NECDisplayCode.NUM_3,
+        NECDisplayCode.NUM_4,
+        NECDisplayCode.NUM_5,
+        NECDisplayCode.NUM_6,
+        NECDisplayCode.NUM_7,
+        NECDisplayCode.NUM_8,
+        NECDisplayCode.NUM_9,
+    ]
+    assert [code.value for code in digits] == list(range(0x08, 0x11))
+    assert NECDisplayCode.NUM_0 == 0x12
+
+
+def test_nec_display_code_round_trips_through_the_decoder() -> None:
+    """Every code must decode back to itself from its own timings."""
+    for code in NECDisplayCode:
+        decoded = ProtonCommand.from_raw_timings(code.to_command().get_raw_timings())
+        assert decoded is not None
+        assert decoded.address == NEC_DISPLAY_ADDRESS
+        assert decoded.command == code.value

--- a/tests/commands/test_proton.py
+++ b/tests/commands/test_proton.py
@@ -1,0 +1,127 @@
+"""Tests for the Proton IR command encoder."""
+
+import pytest
+
+from infrared_protocols.commands.proton import (
+    MID_FRAME_GAP,
+    ONE_LOW,
+    ZERO_LOW,
+    ProtonCommand,
+)
+
+# A power press captured from an NEC RU-M124 projector remote, which a second
+# NEC television remote agrees on.
+NEC_DISPLAY_POWER_TIMINGS: list[int] = [
+    8000, -4000, 500, -500, 500, -500, 500, -1500, 500, -500,
+    500, -1500, 500, -1500, 500, -1500, 500, -1500, 500, -4000,
+    500, -500, 500, -1500, 500, -500, 500, -500, 500, -1500,
+    500, -500, 500, -1500, 500, -500, 500,
+]  # fmt: skip
+
+# Leader (2) + 8 address pairs (16) + mid-frame (2) + 8 command pairs (16) + stop.
+FRAME_ENTRIES = 37
+
+
+def test_proton_command_get_raw_timings_nec_display_power() -> None:
+    """Test Proton timings for an NEC display power press."""
+    command = ProtonCommand(address=0xF4, command=0x52)
+    assert command.get_raw_timings() == NEC_DISPLAY_POWER_TIMINGS
+    assert command.modulation == 38500
+
+
+def test_proton_command_frame_shape() -> None:
+    """The frame carries a mid-frame gap as long as the leader's space."""
+    timings = ProtonCommand(address=0x00, command=0x00).get_raw_timings()
+    assert len(timings) == FRAME_ENTRIES
+    assert timings[18] == 500
+    assert timings[19] == -MID_FRAME_GAP
+
+
+@pytest.mark.parametrize(
+    ("address", "expected_space"),
+    [
+        pytest.param(0x01, -ONE_LOW, id="lsb_set"),
+        pytest.param(0x80, -ZERO_LOW, id="msb_set"),
+    ],
+)
+def test_proton_command_is_lsb_first(address: int, expected_space: int) -> None:
+    """Fields go out least significant bit first.
+
+    This is what separates Proton from the same frame shape in
+    ``GEACCommand``, which sends its bits the other way round.
+    """
+    timings = ProtonCommand(address=address, command=0x00).get_raw_timings()
+    assert timings[3] == expected_space
+
+
+@pytest.mark.parametrize(
+    ("address", "command"),
+    [
+        pytest.param(0x00, 0x00, id="all_clear"),
+        pytest.param(0xFF, 0xFF, id="all_set"),
+        pytest.param(0xF4, 0x52, id="nec_display_power"),
+        pytest.param(0x01, 0x80, id="opposite_ends"),
+    ],
+)
+def test_proton_command_round_trip(address: int, command: int) -> None:
+    """Encoding then decoding must return the original fields."""
+    timings = ProtonCommand(address=address, command=command).get_raw_timings()
+    decoded = ProtonCommand.from_raw_timings(timings)
+    assert decoded is not None
+    assert decoded.address == address
+    assert decoded.command == command
+
+
+def test_proton_command_from_raw_timings_accepts_receiver_jitter() -> None:
+    """A captured frame decodes despite its timings drifting from the ideal."""
+    captured = [
+        8108, -4054, 490, -512, 490, -512, 490, -1535, 490, -512,
+        490, -1535, 490, -1535, 490, -1535, 490, -1535, 490, -4063,
+        490, -512, 490, -1535, 490, -512, 490, -512, 490, -1535,
+        490, -512, 490, -1535, 490, -512, 490,
+    ]  # fmt: skip
+    decoded = ProtonCommand.from_raw_timings(captured)
+    assert decoded is not None
+    assert (decoded.address, decoded.command) == (0xF4, 0x52)
+
+
+@pytest.mark.parametrize(
+    ("timings", "reason"),
+    [
+        pytest.param([], "empty", id="empty"),
+        pytest.param([8000, -4000, 500], "too short", id="too_short"),
+        pytest.param(
+            [1000, *NEC_DISPLAY_POWER_TIMINGS[1:]], "bad leader mark", id="bad_leader"
+        ),
+        pytest.param(
+            [*NEC_DISPLAY_POWER_TIMINGS[:19], -500, *NEC_DISPLAY_POWER_TIMINGS[20:]],
+            "mid-frame gap too short",
+            id="bad_mid_frame_gap",
+        ),
+        pytest.param(
+            [*NEC_DISPLAY_POWER_TIMINGS[:36], 9000],
+            "stop mark too long",
+            id="bad_stop",
+        ),
+    ],
+)
+def test_proton_command_from_raw_timings_rejects(
+    timings: list[int], reason: str
+) -> None:
+    """Timings that are not a Proton frame decode to None."""
+    assert ProtonCommand.from_raw_timings(timings) is None, reason
+
+
+@pytest.mark.parametrize(
+    ("address", "command"),
+    [
+        (-1, 0x00),
+        (0x100, 0x00),
+        (0x00, -1),
+        (0x00, 0x100),
+    ],
+)
+def test_proton_command_rejects_out_of_range(address: int, command: int) -> None:
+    """Proton addresses and commands are both 8-bit."""
+    with pytest.raises(ValueError):
+        ProtonCommand(address=address, command=command)


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Adds Proton support, in two commits: the protocol encoder, then an NEC display codes module that consumes it.

Proton drives NEC Display projectors and televisions, along with Proton and Audiovox devices. Its frame is a leader, eight address bits, a stop mark followed by a second leader-length gap, then eight command bits:

```
Proton    {38.5k,500}<1,-1|1,-3>(16,-8,D:8,1,-8,F:8,1,^63m)*
```

That mid-frame gap is what separates it from NEC, and it is why an NEC-shaped decoder cannot read these frames.

**`NECDisplayCode`** adds 50 codes on address `0xF4`. One command set covers both projectors and televisions, so the module is named for the brand rather than a device class.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: <!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) --> None yet, deliberately, as with #129 and #131.

### Relationship to `GEACCommand`, and why nothing there changes

`GEACCommand` already builds this same frame shape, so this looked at first like a case for generalising it. It is not. The two differ in both bit order and timing unit, and `GEACCommand` is self-consistent with its own codes module, so changing it would break a shipped consumer for no gain.

**Bit order.** The IRP definition carries no `msb` keyword, so Proton is least significant bit first. The digit keys settle it:

| Button | LSB first | MSB first |
| --- | --- | --- |
| 1 | `0x08` | `0x10` |
| 2 | `0x09` | `0x90` |
| 3 | `0x0A` | `0x50` |
| … | … | … |
| 9 | `0x10` | `0x08` |

LSB first yields a contiguous `0x08`–`0x10`. MSB first scatters them.

`GEACCommand` decodes most significant bit first, and that is deliberate rather than a bug. Decoding a captured GE frame both ways:

```
POWER    Proton(LSB) 0xD7/0x0B    GEAC(MSB) 0xEB/0xD0
```

`YAE1K2_ADDRESS` is `0xEB` and `YAE1K2Code.POWER` is `0xD0`, an exact match. Its convention and its codes agree with each other.

**Timing unit.** Measured per capture file: NEC television ~502µs, NEC projector ~505µs, GE AC ~533µs, against the 562µs `GEACCommand` uses. So `ProtonCommand` takes the notation's 500µs and `GEACCommand` keeps its own. Round-trip deviation confirms the split:

```
NEC.ir           n= 26 median= 66us max= 73us
NEC_RU_M124.ir   n= 52 median=109us max=140us
GE_AC.ir         n= 10 median=523us max=527us
```

The class docstring records this, so the two are not merged later by mistake.

### Verification

All 78 NEC-device signals decode, and every one of the 50 declared codes was checked back against the capture it came from: all present, no duplicates, and a maximum re-encode deviation of 140µs on a 500µs unit.

22 of the codes are corroborated by two independent remotes, the projector and the television agreeing on name and value. The remaining 28 come from the projector alone, and are mostly input selection and picture controls a television has no keys for. The module docstring says as much.

### Three things worth a reviewer's eye

- **No `repeat_count`.** The notation does define a 63ms frame period, and 83 of 88 captures contain several frames, so repeats would be justified. Left out to match `GEACCommand`, which encodes a single frame. Easy to add when a consumer needs it.
- **`codes/nec/` is the brand NEC**, and sits alongside `commands/nec.py`, which is the unrelated NEC protocol that these displays do not use. Different namespaces, but the names are close enough to be worth a decision before it is permanent.
- **`NAV_LEFT = 0x22` and `NAV_RIGHT = 0x21`** are reversed from the intuitive order, and the television remote labels those two keys `+` and `-` rather than left and right. The projector's labels were followed since this is a display module, but this is the one entry I would want confirmed against hardware.

### Unrelated observation

While cross-checking, the existing GE YAE1K2 codes disagreed with a crowd-sourced capture of a GE remote on the same `0xEB` address for seven of eight commands. The library has `TEMP_UP = 0x20` where that capture labels `0x20` as fan down, `HIGH = 0x40` against a delay toggle, and so on; only `POWER = 0xD0` agrees. Either the capture's labels are wrong or they are different remotes sharing an address. Nothing is changed here, and the library's values came through a PR with a real consumer, so they are the more trustworthy of the two. Noted only in case it is useful.

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
