### PR TITLE
Add command codes for Sony televisions

### DIFF
--- a/infrared_protocols/codes/sony/tv.py
+++ b/infrared_protocols/codes/sony/tv.py
@@ -1,0 +1,78 @@
+"""Command codes for Sony televisions.
+
+Sony televisions use 12-bit SIRC on address 1, a command set that has stayed
+stable across Bravia generations and their predecessors. Address 1 is not
+exclusive to televisions: Sony remotes for other device types carry these keys
+too, and third-party sets have cloned them.
+
+Codes are unioned across 50 remotes driving this command set. Every entry is
+one that at least three of them agree on, but not every television responds to
+every code. Older sets in particular use ENTER rather than OK to confirm a
+selection.
+"""
+
+from enum import IntEnum
+
+from ...commands import Command
+from ...commands.sony import SonyCommand
+
+SONY_TV_ADDRESS = 0x01
+SONY_TV_ADDRESS_BITS = 5
+
+
+class SonyTVCode(IntEnum):
+    """Sony television IR command codes."""
+
+    POWER = 0x15
+    MUTE = 0x14
+    VOLUME_UP = 0x12
+    VOLUME_DOWN = 0x13
+    CHANNEL_UP = 0x10
+    CHANNEL_DOWN = 0x11
+    INPUT = 0x25
+    SLEEP = 0x36
+
+    NUM_0 = 0x09
+    NUM_1 = 0x00
+    NUM_2 = 0x01
+    NUM_3 = 0x02
+    NUM_4 = 0x03
+    NUM_5 = 0x04
+    NUM_6 = 0x05
+    NUM_7 = 0x06
+    NUM_8 = 0x07
+    NUM_9 = 0x08
+    # Separates major and minor channel numbers, as in 5-1.
+    CHANNEL_DASH = 0x20
+    ENTER = 0x0B
+
+    NAV_UP = 0x74
+    NAV_DOWN = 0x75
+    NAV_LEFT = 0x34
+    NAV_RIGHT = 0x33
+    OK = 0x65
+    HOME = 0x60
+    EXIT = 0x16
+
+    INFO = 0x3A
+    JUMP = 0x3B
+    FAVORITES = 0x18
+    CLOSED_CAPTIONS = 0x23
+    AUDIO = 0x17
+    PICTURE = 0x64
+    TV = 0x24
+    HDMI = 0x39
+    COMPONENT = 0x45
+
+    RED = 0x7A
+    GREEN = 0x7B
+    YELLOW = 0x7C
+    BLUE = 0x7D
+
+    def to_command(self) -> Command:
+        """Build a SONY SIRC command for this Sony television code."""
+        return SonyCommand(
+            address=SONY_TV_ADDRESS,
+            address_bits=SONY_TV_ADDRESS_BITS,
+            command=self.value,
+        )

--- a/tests/codes/test_sony_tv.py
+++ b/tests/codes/test_sony_tv.py
@@ -1,0 +1,79 @@
+"""Tests for the Sony television command codes."""
+
+import pytest
+
+from infrared_protocols.codes.sony.tv import (
+    SONY_TV_ADDRESS,
+    SONY_TV_ADDRESS_BITS,
+    SonyTVCode,
+)
+from infrared_protocols.commands.sony import SonyCommand
+
+# Leader, then two entries per bit for 12 bits, then the trailer.
+SIRC12_ENTRIES = 26
+SIRC_FRAME_PERIOD_US = 45000
+
+
+def test_sony_tv_codes_are_unique() -> None:
+    """Every code must be distinct, since duplicates become silent aliases."""
+    members = SonyTVCode.__members__
+    assert len(members) == len(set(members.values()))
+
+
+def test_sony_tv_code_get_raw_timings_power() -> None:
+    """Test the encoded frame for a Sony television power press."""
+    expected_raw_timings = [
+        2400, -600, 1200, -600, 600, -600, 1200, -600, 600, -600,
+        1200, -600, 600, -600, 600, -600, 1200, -600, 600, -600,
+        600, -600, 600, -600, 600, -25800,
+    ]  # fmt: skip
+    command = SonyTVCode.POWER.to_command()
+    assert command.get_raw_timings() == expected_raw_timings
+    assert command.modulation == 40000
+
+
+@pytest.mark.parametrize(
+    ("code", "command"),
+    [
+        pytest.param(SonyTVCode.POWER, 0x15, id="power"),
+        pytest.param(SonyTVCode.VOLUME_UP, 0x12, id="volume_up"),
+        pytest.param(SonyTVCode.INPUT, 0x25, id="input"),
+        pytest.param(SonyTVCode.OK, 0x65, id="ok"),
+    ],
+)
+def test_sony_tv_code_to_command(code: SonyTVCode, command: int) -> None:
+    """Each code builds a 12-bit SIRC command on the television address."""
+    built = code.to_command()
+    assert isinstance(built, SonyCommand)
+    assert built.address == SONY_TV_ADDRESS
+    assert built.address_bits == SONY_TV_ADDRESS_BITS
+    assert built.command == command
+
+
+def test_sony_tv_digits_are_offset_by_one() -> None:
+    """Digit 1 is command 0x00, so the keypad runs one below its face value.
+
+    Zero sits past nine rather than before one, which is easy to get wrong
+    when transcribing.
+    """
+    digits = [
+        SonyTVCode.NUM_1,
+        SonyTVCode.NUM_2,
+        SonyTVCode.NUM_3,
+        SonyTVCode.NUM_4,
+        SonyTVCode.NUM_5,
+        SonyTVCode.NUM_6,
+        SonyTVCode.NUM_7,
+        SonyTVCode.NUM_8,
+        SonyTVCode.NUM_9,
+    ]
+    assert [code.value for code in digits] == list(range(0x00, 0x09))
+    assert SonyTVCode.NUM_0 == 0x09
+
+
+def test_sony_tv_codes_all_encode_to_a_sirc12_frame() -> None:
+    """Every code must produce a full 12-bit frame padded to the SIRC period."""
+    for code in SonyTVCode:
+        timings = code.to_command().get_raw_timings()
+        assert len(timings) == SIRC12_ENTRIES
+        assert sum(abs(timing) for timing in timings) == SIRC_FRAME_PERIOD_US


### PR DESCRIPTION
<!--
  This library exists to support Home Assistant integrations. Changes
  here should be motivated by a concrete need in Home Assistant Core. Every
  change must therefore be accompanied by a corresponding **draft** PR in the
  home-assistant/core repository that consumes it, so reviewers can see how the
  change is actually used.

  Note: there is no requirement to implement a given protocol or its codes in
  this library. An integration may use a separate, dedicated library instead,
  as long as that library depends on this one for the underlying types. This
  library's primary role is to provide the shared, foundational types.
-->

## Proposed change

<!-- Describe what this PR changes and why. -->

Adds `SonyTVCode`, 40 command codes for Sony televisions. No protocol work: Sony televisions use 12-bit SIRC on address 1, which `SonyCommand` has supported all along. `codes/sony/` held only PlayStation and PSX, so nothing in the library reached a Sony television.

## Additional information

<!--
  Link to the draft PR in home-assistant/core that uses this change. This is
  required: it demonstrates the real-world usage that motivates the change.
-->

- Link to core pull request: <!-- e.g. https://github.com/home-assistant/core/pull/XXXXX (draft) --> None yet, deliberately, as with #129, #131 and #132.

### Evidence

Every code is backed by at least three of the 50 remotes that drive this command set, verified programmatically rather than by eye. The core keys are far above that bar:

```
 cmd  remotes  names
0x12       41  vol_up(39), vol+(2)
0x13       40  vol_dn(35), vol_down(3), vol-(2)
0x15       39  power(30), tv_power(8)
0x14       35  mute(32), muting(3)
0x25       34  input(18), source(9), tv_input(7)
0x74       27  up(24), up_arrow(3)
0x34       26  left(23), left_arrow(3)
0x00-0x08  17  digits 1-9, unanimous
```

All 40 codes were also checked to encode to a 26-entry SIRC12 frame padded to exactly 45000µs.

### The keypad is offset by one

Digit 1 is command `0x00`, so `NUM_9` is `0x08`, and zero sits *past* nine at `0x09` rather than before one. There is a dedicated test for this, because it is precisely the kind of thing that gets transcribed wrongly and then silently sends the wrong channel.

### Where remotes disagree, and why it is not model variation

Checking every common function for whether it maps to more than one command:

```
function   remotes  value distribution
power           39  0x15×38  0x2E×1     <-- split
vol_up          41  0x12×41
mute            35  0x14×35
ch_up           21  0x10×20  0x11×1     <-- split
ch_down         21  0x11×20  0x10×1     <-- split
input           34  0x25×33  0x70×1     <-- split
ok              26  0x65×21  0x0B×5     <-- split
up              27  0x74×27
left            26  0x34×26
```

Naming the minority in each split explains all four:

- **`ch_up`/`ch_down` swapped** on exactly one remote, `Sony_RM-YD028.ir`, against twenty that agree the other way. A capture error.
- **`input` at `0x70`** comes from `Sceptre_H24.ir`, and `0x70` is the `aux_source` code. A wrong label on a non-Sony set.
- **`power` at `0x2E`** is one remote. `0x2E`/`0x2F` look like discrete on/off rather than the toggle, so it is a different function under the same name. Excluded.
- **`ok` at `0x0B`, on five remotes**, is the only real one. `0x0B` is enter, and on older sets it *is* the select key while newer ones use `0x65`. Both are exposed, as `ENTER` and `OK`, so either works. The docstring says so.

Volume, mute and all four cursor keys are unanimous across 24 to 41 remotes, so there is no meaningful per-model divergence here. A per-model support matrix in the style of `marantz/models.py` would have to be invented, since the source is per-remote captures with no per-model support data, so there isn't one.

### Excluded

Fifteen codes present in the wild are left out rather than guessed at:

- `0x63` and `0x3F` — remotes disagree outright (`usb` against `exit`; `tele` against `txt` against `guide`)
- `0x3C` — also labelled `info`, but `0x3A` has 13 remotes behind it against 3, and only one can be `INFO`
- `0x1D` and `0x38` — labelled `sirc_1d` and `sirc_38`, meaning nobody knew
- `0x2E`, `0x2F`, `0x29`, `0x3E`, `0x5C` — one or two remotes each
- `0x6D`–`0x73` — the `aux_*` block, which drives a second device rather than the television

The colour keys `0x7A`–`0x7D` are the one place internal coherence was weighed over raw count: three remotes each, but labelled `a_red`, `b_green`, `c_yellow`, `d_blue` as a consistent block. Named `RED`/`GREEN`/`YELLOW`/`BLUE` to match `lg/tv.py`, `samsung/tv.py` and `vizio/tv.py`.

### On the docstring

The module docstring states what the code set is and what it is not: address 1 is not exclusive to televisions, since Sony remotes for other device types carry these keys and third-party sets have cloned them. Of the 50 source remotes, 29 are televisions and 45 are Sony; the rest are Sony remotes for other device types that carry television keys, plus Sceptre sets using the same command set.

This follows `marantz/audio.py` and `persang/speaker.py`, which both state their source and the limits of what was verified. Several existing brand-level modules (`lg/tv.py`, `samsung/tv.py`, `vizio/tv.py`, `sharp/aquos_tv.py`) say nothing about scope; worth considering as a convention separately, since retrofitting them needs their real provenance rather than a guess.

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
