### PR TITLE
Add AEHA command encoder and decoder

### DIFF
--- a/infrared_protocols/commands/aeha.py
+++ b/infrared_protocols/commands/aeha.py
@@ -16,7 +16,7 @@ constants derived from T.
 """
 
 from dataclasses import dataclass
-from typing import override
+from typing import ClassVar, override
 
 from . import Command
 
@@ -36,6 +36,11 @@ class AehaTiming:
     leader parts differ by a factor of two and a single window cannot fit both. A
     receiver skews a bit by roughly a fixed number of microseconds rather than a fixed
     proportion, so the bit tolerances are absolute microseconds instead.
+
+    The trailer gap is whatever the sender leaves before the next burst, so it is not
+    matched against an expected duration: any space of at least min_trailer_space ends
+    the frame. That floor only has to sit far above a one's space for no distorted bit
+    to be mistaken for the end of the payload.
     """
 
     leader_mark: int = 8 * _NOMINAL_BASE_UNIT
@@ -44,6 +49,7 @@ class AehaTiming:
     zero_space: int = _NOMINAL_BASE_UNIT
     one_space: int = 3 * _NOMINAL_BASE_UNIT
     trailer_space: int = 8000
+    min_trailer_space: int = 4000
     leader_mark_tolerance: float = 0.7
     leader_space_tolerance: float = 0.25
     bit_mark_tolerance: int = 350
@@ -62,7 +68,7 @@ def _is_close(actual: int, expected: int, tolerance: float) -> bool:
 class AehaCommand(Command):
     """AEHA format IR command."""
 
-    TIMING: AehaTiming = AEHA_NOMINAL
+    TIMING: ClassVar[AehaTiming] = AEHA_NOMINAL
     """Physical-layer timings for this AEHA variant."""
 
     data: bytes
@@ -106,10 +112,16 @@ class AehaCommand(Command):
     def _decode_data(cls, timings: list[int]) -> bytes | None:
         """Decode raw IR timings into the payload bytes they carry.
 
-        Returns the payload if the timings open with this variant's leader and hold a
-        whole number of bytes, or None otherwise. Trailing timings that do not complete
-        a byte make the whole burst invalid, since a message truncated mid-byte cannot
-        be trusted.
+        Returns the payload if the timings open with this variant's leader, carry a
+        whole number of bytes and close with the trailer, or None otherwise. Anything
+        else is rejected rather than cut short: a pair that decodes as neither a bit nor
+        the trailer is corruption, and stopping there would hand back a prefix of the
+        payload that looks just like a shorter message. A message truncated mid-byte
+        cannot be trusted either.
+
+        A capture that drops the final gap is still accepted, since some receivers stop
+        recording at the last mark, and timings after the trailer are ignored, since a
+        capture often runs on into the repeat that follows.
         """
         timing = cls.TIMING
         if len(timings) < 2:
@@ -122,11 +134,22 @@ class AehaCommand(Command):
             return None
 
         bits: list[int] = []
-        for i in range(2, len(timings) - 1, 2):
-            bit = cls._decode_bit(timings[i], abs(timings[i + 1]))
-            if bit is None:
+        index = 2
+        while index < len(timings):
+            mark = timings[index]
+            has_space = index + 1 < len(timings)
+            space = abs(timings[index + 1]) if has_space else None
+            if space is None or space >= timing.min_trailer_space:
+                if abs(mark - timing.bit_mark) > timing.bit_mark_tolerance:
+                    return None
                 break
+            bit = cls._decode_bit(mark, space)
+            if bit is None:
+                return None
             bits.append(bit)
+            index += 2
+        else:
+            return None
 
         if not bits or len(bits) % 8:
             return None

--- a/infrared_protocols/commands/aeha.py
+++ b/infrared_protocols/commands/aeha.py
@@ -46,7 +46,7 @@ class AehaTiming:
     trailer_space: int = 8000
     leader_mark_tolerance: float = 0.7
     leader_space_tolerance: float = 0.25
-    bit_mark_tolerance: int = 360
+    bit_mark_tolerance: int = 350
     bit_space_tolerance: int = 350
 
 

--- a/infrared_protocols/commands/aeha.py
+++ b/infrared_protocols/commands/aeha.py
@@ -1,0 +1,147 @@
+"""AEHA format IR command.
+
+Everything is expressed in multiples of a base
+time unit T, nominally 425 us but allowed anywhere between 350 and 500:
+
+  leader:   8T mark, 4T space
+  bit:      1T mark, then 1T space for a zero and 3T space for a one
+  trailer:  1T mark, then a long space
+
+Payload bytes are sent least-significant bit first. What those bytes mean is left to the
+protocol built on top: this module only carries them.
+
+Vendors round the base unit differently, and some do not keep a single one across the
+leader and the bits, so the timings are a value object a subclass overrides rather than
+constants derived from T.
+"""
+
+from dataclasses import dataclass
+from typing import override
+
+from . import Command
+
+_NOMINAL_BASE_UNIT = 425
+"""Nominal base time unit for AEHA, in microseconds."""
+
+
+@dataclass(frozen=True, slots=True)
+class AehaTiming:
+    """Physical-layer timings for one AEHA variant, in microseconds.
+
+    The defaults are the nominal AEHA values. The tolerances are deliberately
+    asymmetric: an IR receiver's AGC distorts marks far more than spaces, so the mark
+    only has to be plausible and the space is what decides the bit.
+
+    The leader tolerances are a fraction of the expected duration, since the two
+    leader parts differ by a factor of two and a single window cannot fit both. A
+    receiver skews a bit by roughly a fixed number of microseconds rather than a fixed
+    proportion, so the bit tolerances are absolute microseconds instead.
+    """
+
+    leader_mark: int = 8 * _NOMINAL_BASE_UNIT
+    leader_space: int = 4 * _NOMINAL_BASE_UNIT
+    bit_mark: int = _NOMINAL_BASE_UNIT
+    zero_space: int = _NOMINAL_BASE_UNIT
+    one_space: int = 3 * _NOMINAL_BASE_UNIT
+    trailer_space: int = 8000
+    leader_mark_tolerance: float = 0.7
+    leader_space_tolerance: float = 0.25
+    bit_mark_tolerance: int = 360
+    bit_space_tolerance: int = 350
+
+
+AEHA_NOMINAL = AehaTiming()
+
+
+def _is_close(actual: int, expected: int, tolerance: float) -> bool:
+    """Check if a timing is within the given relative tolerance of the expected."""
+    margin = expected * tolerance
+    return expected - margin <= actual <= expected + margin
+
+
+class AehaCommand(Command):
+    """AEHA format IR command."""
+
+    TIMING: AehaTiming = AEHA_NOMINAL
+    """Physical-layer timings for this AEHA variant."""
+
+    data: bytes
+    """Payload bytes, sent least-significant bit first."""
+
+    def __init__(
+        self,
+        *,
+        data: bytes,
+        modulation: int = 38000,
+    ) -> None:
+        """Initialize the AEHA IR command."""
+        super().__init__(modulation=modulation)
+        self.data = data
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the AEHA command.
+
+        AEHA protocol timing (in base time units):
+        - T: base time unit (350µs - 500µs, 425µs typ.)
+        - Leader pulse: 8T high, 4T low
+        - Logical '0': 1T high, 1T low
+        - Logical '1': 1T high, 3T low
+        - End pulse: 1T high, then a long space
+
+        Data format (variable length, LSB first).
+        """
+        timing = self.TIMING
+        timings: list[int] = [timing.leader_mark, -timing.leader_space]
+        for byte in self.data:
+            for i in range(8):
+                timings.append(timing.bit_mark)
+                one = (byte >> i) & 1
+                timings.append(-(timing.one_space if one else timing.zero_space))
+        timings.append(timing.bit_mark)
+        timings.append(-timing.trailer_space)
+        return timings
+
+    @classmethod
+    def _decode_data(cls, timings: list[int]) -> bytes | None:
+        """Decode raw IR timings into the payload bytes they carry.
+
+        Returns the payload if the timings open with this variant's leader and hold a
+        whole number of bytes, or None otherwise. Trailing timings that do not complete
+        a byte make the whole burst invalid, since a message truncated mid-byte cannot
+        be trusted.
+        """
+        timing = cls.TIMING
+        if len(timings) < 2:
+            return None
+        if not _is_close(
+            timings[0], timing.leader_mark, timing.leader_mark_tolerance
+        ) or not _is_close(
+            abs(timings[1]), timing.leader_space, timing.leader_space_tolerance
+        ):
+            return None
+
+        bits: list[int] = []
+        for i in range(2, len(timings) - 1, 2):
+            bit = cls._decode_bit(timings[i], abs(timings[i + 1]))
+            if bit is None:
+                break
+            bits.append(bit)
+
+        if not bits or len(bits) % 8:
+            return None
+        return bytes(
+            sum(bits[i + j] << j for j in range(8)) for i in range(0, len(bits), 8)
+        )
+
+    @classmethod
+    def _decode_bit(cls, mark: int, space: int) -> int | None:
+        """Decode one bit from its mark and space, or None if it matches neither."""
+        timing = cls.TIMING
+        if abs(mark - timing.bit_mark) > timing.bit_mark_tolerance:
+            return None
+        if abs(space - timing.zero_space) <= timing.bit_space_tolerance:
+            return 0
+        if abs(space - timing.one_space) <= timing.bit_space_tolerance:
+            return 1
+        return None

--- a/tests/commands/test_aeha.py
+++ b/tests/commands/test_aeha.py
@@ -1,0 +1,221 @@
+"""Tests for the AEHA physical layer."""
+
+import pytest
+
+from infrared_protocols.commands.aeha import AEHA_NOMINAL, AehaCommand, AehaTiming
+
+# Physical-layer constants are duplicated here rather than imported
+# so the tests are independent
+_BASE_UNIT = 425
+_LEADER_MARK = 8 * _BASE_UNIT
+_LEADER_SPACE = 4 * _BASE_UNIT
+_BIT_MARK = _BASE_UNIT
+_ZERO_SPACE = _BASE_UNIT
+_ONE_SPACE = 3 * _BASE_UNIT
+_TRAILER_SPACE = 8000
+
+
+class _VariantCommand(AehaCommand):
+    """A variant whose vendor rounded the base unit differently."""
+
+    TIMING = AehaTiming(
+        leader_mark=3300,
+        leader_space=1600,
+        bit_mark=420,
+        zero_space=420,
+        one_space=1200,
+    )
+
+
+def _timings_for(data: bytes, timing: AehaTiming = AEHA_NOMINAL) -> list[int]:
+    """Build raw timings for a payload without going through the encoder."""
+    timings = [timing.leader_mark, -timing.leader_space]
+    for byte in data:
+        for bit in range(8):
+            one = (byte >> bit) & 1
+            timings += [
+                timing.bit_mark,
+                -(timing.one_space if one else timing.zero_space),
+            ]
+    return timings + [timing.bit_mark, -timing.trailer_space]
+
+
+def test_nominal_timings() -> None:
+    """The default timings must be the nominal 8T/4T leader and 1T/3T bits."""
+    timings = AehaCommand(data=b"\x01").get_raw_timings()
+
+    assert timings[:2] == [_LEADER_MARK, -_LEADER_SPACE]
+    assert timings[-2:] == [_BIT_MARK, -_TRAILER_SPACE]
+    assert set(timings[2:-2:2]) == {_BIT_MARK}
+    assert set(timings[3:-2:2]) <= {-_ONE_SPACE, -_ZERO_SPACE}
+
+
+def test_bytes_are_sent_least_significant_bit_first() -> None:
+    """A payload byte must go out with its low bit first."""
+    timings = AehaCommand(data=b"\x01").get_raw_timings()
+
+    spaces = [abs(space) for space in timings[3:-2:2]]
+
+    assert spaces == [_ONE_SPACE] + [_ZERO_SPACE] * 7
+
+
+def test_default_modulation() -> None:
+    """Default modulation must be 38 kHz."""
+    command = AehaCommand(data=b"\x00")
+
+    assert command.modulation == 38000
+    assert command.repeat_count == 0
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(b"\x00", id="single_zero_byte"),
+        pytest.param(b"\xff", id="single_full_byte"),
+        pytest.param(b"\x14\x63\x00\x10\x10\x02\xfd", id="seven_bytes"),
+        pytest.param(bytes(range(16)), id="sixteen_bytes"),
+    ],
+)
+def test_roundtrip(data: bytes) -> None:
+    """Encoding then decoding a payload must return it unchanged."""
+    timings = AehaCommand(data=data).get_raw_timings()
+
+    assert AehaCommand._decode_data(timings) == data
+
+
+def test_variant_timings_are_used_for_both_directions() -> None:
+    """A subclass's timings must drive its encoding and its decoding."""
+    command = _VariantCommand(data=b"\x14\x63")
+    timings = command.get_raw_timings()
+
+    assert timings[:2] == [3300, -1600]
+    assert _VariantCommand._decode_data(timings) == b"\x14\x63"
+
+
+def test_variants_within_receiver_tolerance_decode_each_other() -> None:
+    """Variants that differ by less than a receiver's own error are interchangeable.
+
+    The tolerances are wide enough to absorb real receiver distortion, which is larger
+    than the gap between two vendors' roundings of the base unit. A protocol built on
+    this layer therefore has to identify itself from its payload, not from its timings.
+    """
+    nominal = AehaCommand(data=b"\x14").get_raw_timings()
+
+    assert _VariantCommand._decode_data(nominal) == b"\x14"
+
+
+@pytest.mark.parametrize(
+    ("index", "value"),
+    [
+        pytest.param(0, 9000, id="leader_mark_too_long"),
+        pytest.param(0, 500, id="leader_mark_too_short"),
+        pytest.param(1, -4500, id="leader_space_too_long"),
+        pytest.param(1, -600, id="leader_space_too_short"),
+    ],
+)
+def test_decode_rejects_bad_leader(index: int, value: int) -> None:
+    """A burst that does not open with the leader must not decode."""
+    timings = _timings_for(b"\x14\x63")
+    timings[index] = value
+
+    assert AehaCommand._decode_data(timings) is None
+
+
+@pytest.mark.parametrize(
+    "timings",
+    [
+        pytest.param([], id="empty"),
+        pytest.param([_LEADER_MARK], id="leader_mark_only"),
+        pytest.param([_LEADER_MARK, -_LEADER_SPACE], id="leader_only"),
+    ],
+)
+def test_decode_rejects_too_short(timings: list[int]) -> None:
+    """Timings with no payload at all must not decode."""
+    assert AehaCommand._decode_data(timings) is None
+
+
+def test_decode_rejects_partial_byte() -> None:
+    """A burst that stops mid-byte cannot be trusted, so it must not decode."""
+    timings = _timings_for(b"\x14\x63")
+    # Drop the last three bit pairs, leaving 13 bits.
+    truncated = timings[: 2 + 2 * 13]
+
+    assert AehaCommand._decode_data(truncated) is None
+
+
+def test_decode_stops_at_the_trailer() -> None:
+    """The trailer's long space ends the payload rather than decoding as a bit."""
+    timings = _timings_for(b"\x14\x63")
+
+    assert AehaCommand._decode_data(timings) == b"\x14\x63"
+    assert len(timings) == 2 + 2 * 16 + 2
+
+
+def test_decode_stops_at_the_first_timing_that_is_not_a_bit() -> None:
+    """Whatever follows a whole payload ends it, the trailer being one such thing.
+
+    The trailer is not special-cased, so a burst that runs into another signal, or into
+    noise, still yields the bytes it did carry as long as they are whole.
+    """
+    timings = _timings_for(b"\x14\x63")[:-2] + [_BIT_MARK, -900, _BIT_MARK, -900]
+
+    assert AehaCommand._decode_data(timings) == b"\x14\x63"
+
+
+@pytest.mark.parametrize(
+    ("mark", "space", "expected"),
+    [
+        pytest.param(_BIT_MARK, _ZERO_SPACE, b"\x00", id="nominal_zero"),
+        pytest.param(_BIT_MARK, _ONE_SPACE, b"\xff", id="nominal_one"),
+        pytest.param(65, _ZERO_SPACE, b"\x00", id="mark_at_lower_edge"),
+        pytest.param(785, _ZERO_SPACE, b"\x00", id="mark_at_upper_edge"),
+        pytest.param(_BIT_MARK, 775, b"\x00", id="zero_space_at_upper_edge"),
+        pytest.param(_BIT_MARK, 925, b"\xff", id="one_space_at_lower_edge"),
+    ],
+)
+def test_decode_accepts_distorted_bits(mark: int, space: int, expected: bytes) -> None:
+    """Bits inside the tolerance windows must decode, however distorted."""
+    timings = [_LEADER_MARK, -_LEADER_SPACE]
+    for _ in range(8):
+        timings += [mark, -space]
+    timings += [_BIT_MARK, -_TRAILER_SPACE]
+
+    assert AehaCommand._decode_data(timings) == expected
+
+
+@pytest.mark.parametrize(
+    ("mark", "space"),
+    [
+        pytest.param(20, _ZERO_SPACE, id="mark_below_window"),
+        pytest.param(900, _ZERO_SPACE, id="mark_above_window"),
+        pytest.param(_BIT_MARK, 810, id="space_between_zero_and_one"),
+        pytest.param(_BIT_MARK, 1700, id="space_above_one"),
+    ],
+)
+def test_decode_rejects_bits_outside_the_windows(mark: int, space: int) -> None:
+    """A first bit that matches neither window leaves no payload to decode."""
+    timings = [_LEADER_MARK, -_LEADER_SPACE]
+    for _ in range(8):
+        timings += [mark, -space]
+    timings += [_BIT_MARK, -_TRAILER_SPACE]
+
+    assert AehaCommand._decode_data(timings) is None
+
+
+def test_decode_rejects_a_foreign_burst() -> None:
+    """Timings that are not AEHA at all must not decode."""
+    assert AehaCommand._decode_data([500, -500, 300, -300]) is None
+
+
+def test_timing_is_immutable() -> None:
+    """Timings are a value object, so a variant cannot be mutated in place."""
+    with pytest.raises(AttributeError):
+        AEHA_NOMINAL.bit_mark = 999  # type: ignore[misc]
+
+
+def test_empty_payload_encodes_to_leader_and_trailer_only() -> None:
+    """An empty payload must still produce a well-formed, if useless, burst."""
+    timings = AehaCommand(data=b"").get_raw_timings()
+
+    assert timings == [_LEADER_MARK, -_LEADER_SPACE, _BIT_MARK, -_TRAILER_SPACE]
+    assert AehaCommand._decode_data(timings) is None

--- a/tests/commands/test_aeha.py
+++ b/tests/commands/test_aeha.py
@@ -167,8 +167,8 @@ def test_decode_stops_at_the_first_timing_that_is_not_a_bit() -> None:
     [
         pytest.param(_BIT_MARK, _ZERO_SPACE, b"\x00", id="nominal_zero"),
         pytest.param(_BIT_MARK, _ONE_SPACE, b"\xff", id="nominal_one"),
-        pytest.param(65, _ZERO_SPACE, b"\x00", id="mark_at_lower_edge"),
-        pytest.param(785, _ZERO_SPACE, b"\x00", id="mark_at_upper_edge"),
+        pytest.param(75, _ZERO_SPACE, b"\x00", id="mark_at_lower_edge"),
+        pytest.param(775, _ZERO_SPACE, b"\x00", id="mark_at_upper_edge"),
         pytest.param(_BIT_MARK, 775, b"\x00", id="zero_space_at_upper_edge"),
         pytest.param(_BIT_MARK, 925, b"\xff", id="one_space_at_lower_edge"),
     ],

--- a/tests/commands/test_aeha.py
+++ b/tests/commands/test_aeha.py
@@ -151,13 +151,45 @@ def test_decode_stops_at_the_trailer() -> None:
     assert len(timings) == 2 + 2 * 16 + 2
 
 
-def test_decode_stops_at_the_first_timing_that_is_not_a_bit() -> None:
-    """Whatever follows a whole payload ends it, the trailer being one such thing.
+def test_decode_rejects_corruption_at_a_byte_boundary() -> None:
+    """A damaged bit must reject the burst, not end the payload early.
 
-    The trailer is not special-cased, so a burst that runs into another signal, or into
-    noise, still yields the bytes it did carry as long as they are whole.
+    Corruption that lands on a byte boundary would otherwise leave a whole number of
+    bytes behind, and a prefix of the payload is indistinguishable from a shorter
+    message once it is returned.
     """
+    timings = _timings_for(b"\x14\x63")
+    # Damage the first bit of the second byte, leaving one whole byte before it.
+    timings[2 + 2 * 8 + 1] = -900
+
+    assert AehaCommand._decode_data(timings) is None
+
+
+def test_decode_rejects_a_burst_that_runs_into_noise() -> None:
+    """Bits that never reach a trailer must not decode."""
     timings = _timings_for(b"\x14\x63")[:-2] + [_BIT_MARK, -900, _BIT_MARK, -900]
+
+    assert AehaCommand._decode_data(timings) is None
+
+
+def test_decode_rejects_a_trailer_whose_mark_is_not_a_bit_mark() -> None:
+    """The trailer's mark is one bit mark, so any other ending is not AEHA."""
+    timings = _timings_for(b"\x14\x63")
+    timings[-2] = 3000
+
+    assert AehaCommand._decode_data(timings) is None
+
+
+def test_decode_tolerates_a_missing_trailer_space() -> None:
+    """Some receivers stop recording at the last mark, so the final gap is optional."""
+    timings = _timings_for(b"\x14\x63")[:-1]
+
+    assert AehaCommand._decode_data(timings) == b"\x14\x63"
+
+
+def test_decode_ignores_timings_after_the_trailer() -> None:
+    """A capture that runs on into the repeat that follows must still decode."""
+    timings = _timings_for(b"\x14\x63") + _timings_for(b"\x14\x63")
 
     assert AehaCommand._decode_data(timings) == b"\x14\x63"
 


### PR DESCRIPTION
## Proposed change

Adds the AEHA physical layer as a reusable command, split out of the Fujitsu General air-conditioner work so the generic framing lands on its own.

AEHA is the Japanese consumer-electronics IR framing shared by several vendors. Everything is expressed in multiples of a base time unit T, nominally 425 us but allowed anywhere between 350 and 500:

- leader: 8T mark, 4T space
- bit: 1T mark, then 1T space for a zero and 3T space for a one
- trailer: 1T mark, then a long space

Payload bytes are sent least-significant bit first. What those bytes mean is left to the protocol built on top; this module only carries them.

Vendors round the base unit differently, and some do not keep a single one across the leader and the bits, so the timings are a value object a subclass overrides rather than constants derived from T.

The first consumer is the Fujitsu General AC protocol, which is a separate PR on top of this one so each layer can be reviewed on its own.

## Additional information

- Link to core pull request: to follow

The core integration consumes the Fujitsu General AC command rather than this layer directly, so nothing in core uses this PR on its own. I will open the core draft PR once this and the Fujitsu General AC PR are merged, and link it here.

## Checklist

- [ ] I have linked a draft PR in `home-assistant/core` that consumes this change.
- [x] Lint, format, and type checks pass (`prek --all-files`).
- [x] Tests pass (`pytest`).
